### PR TITLE
Phase 2: Fixed timestep, pausable GameClock, and system extraction

### DIFF
--- a/docs/SYSTEMS_ROADMAP.md
+++ b/docs/SYSTEMS_ROADMAP.md
@@ -19,7 +19,9 @@ Guiding constraints:
 > **Note (post-Phase 1):** this section describes the code as found. Phase 0 deleted the
 > dead weight and Phase 1 moved `js/*.js` to `src/legacy/*.ts` under Vite — file paths
 > below are the originals. The pathologies themselves are all still there; that is what
-> Phases 2+ are for.
+> Phases 2+ are for. **Post-Phase 2:** pathology #4 (framerate-dependent simulation and
+> raw wall-clock AI timers) is fixed — fixed 60 Hz timestep plus the pausable
+> `GameClock`.
 
 The game is plain ES5 loaded as 27 ordered `<script>` tags in `game.html`, sharing ~100
 globals. Pixi.js v3 is vendored in `bin/`. There is no npm, no bundler, no modules — the
@@ -535,7 +537,7 @@ Two things landed on top of the conversion, both at the maintainer's request:
   can't skew aim either. Verified with a pinned-camera probe: screen-to-world is now
   identical at devicePixelRatio 1, 2 and 3.
 
-### Phase 2 — Core loop: fixed timestep, clock, events (~1 week)
+### Phase 2 — Core loop: fixed timestep, clock, events (~1 week) ✅ done
 
 Accumulator-based fixed 60 Hz update (fixes framerate-dependent speed — a prerequisite for
 physics tuning). A pausable `GameClock` (`after(ms)`, `every(ms)`) replaces every raw
@@ -544,6 +546,70 @@ makes pause real. Event bus lands. Extract 2–3 easy systems (input, camera, pa
 prove the strangler loop.
 **Verify:** cap FPS at 30 — movement speed unchanged; pause mid-"investigate" — the timer
 resumes correctly. Unit tests: clock.
+
+#### What shipped
+
+- **Fixed 60 Hz timestep.** `animate()` accumulates wall time and runs `gameloop()` in
+  fixed `1000/60` ms steps; per-frame movement constants are now per-*tick* constants, so
+  game speed is independent of the display's refresh rate. Frame deltas are clamped to
+  250 ms (a backgrounded tab or a too-slow machine slows down instead of freezing in a
+  catch-up spiral), and `startGame` resets the accumulator so a stay in the menu isn't
+  simulated as one burst.
+- **`GameClock`** (`src/core/clock.ts`, strict TS): `now() / after(ms) / every(ms) /
+  cancel / clear`, ticked once per fixed step from `gameloop()` — so pausing the game
+  freezes every pending gameplay timer for free, and timers can no longer fire into a
+  torn-down run. Every raw gameplay `setTimeout` migrated: guard shoot-reaction, guard
+  see-something-alarming reaction and its alert-the-others chain (guards *and* cameras),
+  `setLastSeen`'s 2 s confirmation, the choke-out kill, backup spawn waves, and the alert
+  icon's hide delay. The patrol-repath backoff from Phase 0 now counts game time
+  (`gameClock.now()`), not wall time, so pause doesn't burn it down. `clearStage()`'s
+  clear-*every*-timeout-id-on-the-page hack is one `gameClock.clear()` now.
+- **Event bus** (`src/core/events.ts`): `on/off/emit`, with one real subscriber to prove
+  the seam — camera kickback is now `events.emit('camera:kickback')` from the two shoot
+  paths, and the camera system listens. Sounds, wall destruction and squad signals plug
+  into the same bus in Phases 5–6.
+- **Three systems extracted** from `main.ts` (roadmap §2.2, mechanical move — they still
+  read shared world state as window globals, but legacy files now *import* the extracted
+  functions, and ~20 names left `legacy-globals.d.ts` and the window republish lists):
+  - `src/systems/input.ts` — key/mouse/wheel handlers, `removeHandlers`, the walk
+    animation check. `hero_moving` became a module local.
+  - `src/systems/camera.ts` — zoom, loose follow + clamping, shake, kickback.
+    `kickback_speed/amount` became module locals; dead `scaleStageChild` deleted.
+  - `src/systems/particles.ts` — shells/shards/blood ticking (`updateParticles`), the
+    splatter/eject spawners. `shard/shell/shard_limit/shell_speed/blood_speed` became
+    module locals.
+  `main.ts` is down to 2,297 lines from 2,969.
+
+#### Phase 2 verification
+
+22 new Vitest cases (clock: ordering, catch-up without drift, cancel/clear mid-update,
+the nested-timer pattern the guard AI uses; bus: subscribe/unsubscribe during emit) on
+top of the Phase 1 suites — 67 total, all green, plus typecheck and production build.
+
+Headless Playwright (software rendering, so "native" is CPU-bound ~22–25 FPS; the caps
+skip every 2nd/4th rAF callback). Hero walk speed, design value **240 px/s** (4 px/tick
+× 60 Hz):
+
+| build | ~25 FPS | ~21 FPS | ~13 FPS |
+|---|---|---|---|
+| pre-Phase 2 | 80.3 px/s | 77.6 px/s | 46.6 px/s |
+| Phase 2 | 238.7–240.4 px/s | 240.3 px/s | 235.0 px/s |
+
+The old build moves at a third of the intended speed *at its normal headless framerate* —
+speed simply tracked FPS. The new build holds the design speed everywhere.
+
+Pause semantics, verified end-to-end on both `vite dev` and the production build: a guard
+in the 500 ms alarmed-pre reaction stays un-alarmed through a 1.5 s pause and alarms
+~500 ms after resume; backup waves stop landing the moment `pause` is set (2 spawned
+before, 0 during a 2.5 s pause, all 4 after resume); the bomb fuse freezes mid-countdown
+and resumes; the blast still opens walls (9 cells) and kills a hero standing in it.
+Kickback still fires through the bus; no console errors.
+
+One vindication found while measuring: the first FPS-cap attempt replaced
+`requestAnimationFrame` with a `setTimeout`-based fake, and on the *old* build the game
+froze at the menu→game transition — `clearStage()`'s clear-all-timeouts hack was killing
+the render loop's pending timeout. Exactly the class of friendly-fire the `GameClock`
+migration removes.
 
 ### Phase 3 — Pathfinding v2 (~1–2 weeks)
 

--- a/src/core/clock.ts
+++ b/src/core/clock.ts
@@ -1,0 +1,116 @@
+/**
+ * GameClock — pausable, restartable gameplay time (roadmap Phase 2).
+ *
+ * All gameplay delays go through this instead of raw `setTimeout`/`new Date()`.
+ * The clock only advances when `update(dt)` is called, and `update` is only called
+ * from the fixed-timestep gameloop — so pausing the game pauses every pending timer
+ * for free, and `clear()` on restart kills the whole batch at once (the old code
+ * looped over every window timeout id to get the same effect).
+ *
+ * Deliberately NOT wall-clock time: `now()` is milliseconds of *simulated* time since
+ * the clock was created/cleared. Anything that should keep running while paused
+ * (real-world UI, say) does not belong here.
+ */
+
+export type ClockCallback = () => void;
+
+export interface ClockHandle {
+  /** True once the timer has fired for the last time or been cancelled. */
+  readonly done: boolean;
+  cancel(): void;
+}
+
+interface Timer {
+  /** Absolute clock time (ms) at which this timer next fires. */
+  dueAt: number;
+  /** Repeat interval in ms; 0 for one-shots. */
+  intervalMs: number;
+  callback: ClockCallback;
+  cancelled: boolean;
+}
+
+class Handle implements ClockHandle {
+  constructor(private timer: Timer) {}
+  get done(): boolean {
+    return this.timer.cancelled;
+  }
+  cancel(): void {
+    this.timer.cancelled = true;
+  }
+}
+
+export class GameClock {
+  private timeMs = 0;
+  private timers: Timer[] = [];
+
+  /** Milliseconds of simulated (unpaused) time since creation or the last clear(). */
+  now(): number {
+    return this.timeMs;
+  }
+
+  /** Run `callback` once, `ms` from now in game time. Non-positive delays fire on the next update. */
+  after(ms: number, callback: ClockCallback): ClockHandle {
+    return this.add(this.timeMs + Math.max(0, ms), 0, callback);
+  }
+
+  /** Run `callback` every `ms` of game time, first firing `ms` from now. */
+  every(ms: number, callback: ClockCallback): ClockHandle {
+    if (ms <= 0) throw new Error('GameClock.every() needs a positive interval');
+    return this.add(this.timeMs + ms, ms, callback);
+  }
+
+  /** Cancel every pending timer (used on game restart). */
+  clear(): void {
+    for (const timer of this.timers) timer.cancelled = true;
+    this.timers = [];
+  }
+
+  /**
+   * Advance game time by `dt` ms and fire everything that came due, in global due
+   * order — repeating `every()` beats interleave correctly with one-shots when one
+   * update spans several intervals. Callbacks may schedule new timers (they wait
+   * for a later update), cancel other timers, or clear() the whole clock — all
+   * safe mid-update.
+   */
+  update(dt: number): void {
+    if (dt < 0) return;
+    this.timeMs += dt;
+
+    // Snapshot: timers scheduled by callbacks during this update must not fire in it
+    // (a callback chaining `after(0, ...)` would otherwise loop forever in one tick).
+    const snapshot = new Set(this.timers);
+
+    // Pull the earliest due timer each round. Linear scan, but gameplay holds a
+    // handful of timers at a time — correctness of ordering matters more here.
+    for (;;) {
+      let next: Timer | null = null;
+      for (const t of this.timers) {
+        if (t.cancelled || !snapshot.has(t) || t.dueAt > this.timeMs) continue;
+        if (next === null || t.dueAt < next.dueAt) next = t;
+      }
+      if (next === null) break;
+      if (next.intervalMs > 0) {
+        next.dueAt += next.intervalMs; // one beat per elapsed interval, no drift
+      } else {
+        next.cancelled = true;
+      }
+      next.callback();
+    }
+
+    this.timers = this.timers.filter((t) => !t.cancelled);
+  }
+
+  /** Pending (not yet fired/cancelled) timer count — used by tests and debug overlays. */
+  pendingCount(): number {
+    return this.timers.filter((t) => !t.cancelled).length;
+  }
+
+  private add(dueAt: number, intervalMs: number, callback: ClockCallback): ClockHandle {
+    const timer: Timer = { dueAt, intervalMs, callback, cancelled: false };
+    this.timers.push(timer);
+    return new Handle(timer);
+  }
+}
+
+/** The game's clock. Ticked once per fixed step from gameloop(); cleared on restart. */
+export const gameClock = new GameClock();

--- a/src/core/events.ts
+++ b/src/core/events.ts
@@ -1,0 +1,40 @@
+/**
+ * Event bus (roadmap §2.2) — the seam later systems plug into: wall destruction,
+ * AI stimuli (sounds), squad notifications, FX.
+ *
+ * Kept intentionally tiny. Events are named strings; payloads are whatever the
+ * emitter sends. As real event types appear (Phase 5's 'cell:destroyed', Phase 6's
+ * sound stimuli) they get typed payload interfaces at their emit site.
+ */
+
+export type EventHandler = (payload?: unknown) => void;
+
+export class EventBus {
+  private handlers = new Map<string, EventHandler[]>();
+
+  /** Subscribe. Returns an unsubscribe function. */
+  on(event: string, handler: EventHandler): () => void {
+    const list = this.handlers.get(event) ?? [];
+    list.push(handler);
+    this.handlers.set(event, list);
+    return () => this.off(event, handler);
+  }
+
+  off(event: string, handler: EventHandler): void {
+    const list = this.handlers.get(event);
+    if (!list) return;
+    const i = list.indexOf(handler);
+    if (i !== -1) list.splice(i, 1);
+    if (list.length === 0) this.handlers.delete(event);
+  }
+
+  /** Fire `event`. Handlers may subscribe/unsubscribe during emit without skipping anyone. */
+  emit(event: string, payload?: unknown): void {
+    const list = this.handlers.get(event);
+    if (!list) return;
+    for (const handler of [...list]) handler(payload);
+  }
+}
+
+/** The game's bus. */
+export const events = new EventBus();

--- a/src/legacy-globals.d.ts
+++ b/src/legacy-globals.d.ts
@@ -158,15 +158,12 @@ declare global {
   var DEFAULT_LEVEL: any;
   var DEFAULT_VOLUME: any;
   var BLOOD_TRAIL_BAKE_EVERY: any;
-  var addKeyHandlers: any;
   var alarmingObjects: any;
   var alert_all_guards: any;
   var alert_clip: any;
   var animate: any;
   var backupCalled: any;
   var bakeBloodTrail: any;
-  var bloodParticleSplatter: any;
-  var blood_speed: any;
   var blood_trail: any;
   var blood_trail_pending: any;
   var blood_trail_sprite: any;
@@ -184,7 +181,6 @@ declare global {
   var bullets: any;
   var camera: any;
   var cameras_disabled: any;
-  var changeFontSizes: any;
   var circProgBar: any;
   var clearStage: any;
   var clickEvent: any;
@@ -205,7 +201,6 @@ declare global {
   var dragDistance: any;
   var drawBloodTrail: any;
   var drop_gun: any;
-  var ejectShell: any;
   var enableLOS: any;
   var explodeBomb: any;
   var fullscreen: any;
@@ -219,7 +214,6 @@ declare global {
   var gameloop_guards: any;
   var gameloop_messages_and_tooltip: any;
   var gameloop_security_cams: any;
-  var gameloop_zoom_and_camera: any;
   var getColor: any;
   var getMapInfo: any;
   var getUrlVars: any;
@@ -235,15 +229,14 @@ declare global {
   var hero_end_aim_coord: any;
   var hero_is_dead: any;
   var hero_last_seen: any;
-  var hero_move_animation_check: any;
-  var hero_moving: any;
   var keys: any;
-  var kickback: any;
-  var kickback_amount: any;
-  var kickback_speed: any;
   var killHero: any;
   var lastTimeStamp: any;
   var latestAlert: any;
+  // Fixed-timestep state (Phase 2): the sim always steps in STEP_MS increments.
+  var STEP_MS: number;
+  var MAX_FRAME_MS: number;
+  var step_accumulator: number;
   var look_sensitivity: any;
   var loot: any;
   var losPathGraphics: any;
@@ -262,8 +255,6 @@ declare global {
   var messageText: any;
   var messages_floating: any;
   var mouse: any;
-  var mouseMove: any;
-  var mouseWheelHandler: any;
   var mouse_relative: any;
   var newFloatingMessage: any;
   var newMessage: any;
@@ -276,17 +267,13 @@ declare global {
   var plantBomb: any;
   var reactionTimeout: any;
   var removeAllChildren: any;
-  var removeHandlers: any;
   var renderer: any;
-  var scaleStageChild: any;
   var security_cameras: any;
   var setBomb: any;
   var setHeroImage: any;
   var set_latestAlert: any;
   var setup_map: any;
-  var shardParticleSplatter: any;
   var shardType: any;
-  var shard_limit: any;
   var shards: any;
   var shell1: any;
   var shell2: any;
@@ -295,7 +282,6 @@ declare global {
   var shell5: any;
   var shellTextures: any;
   var shellType: any;
-  var shell_speed: any;
   var shells: any;
   var show_sprite_tooltips: any;
   var spawn_backup: any;
@@ -312,7 +298,6 @@ declare global {
   var states: any;
   var static_effect_sprites: any;
   var stats: any;
-  var tickParticle: any;
   var tooltip: any;
   var tooltipshown: any;
   var unsilenced_gun: any;
@@ -337,9 +322,7 @@ declare global {
   var currentShard: any;
   var mouse_click_obj: any;
   var percent: any;
-  var shard: any;
   var shardImages: any;
-  var shell: any;
 
   // Sprite-sheet frame handles, all assigned in images_from_sheet.ts:onAssetsLoaded().
   var img_blue: any;

--- a/src/legacy/jo_security_camera.ts
+++ b/src/legacy/jo_security_camera.ts
@@ -3,6 +3,7 @@ Copyright 2014,2015, Jordan O'Leary, All rights reserved.
 If you would like to copy or use my code, you may contact
 me at jdoleary@gmail.com
 /*******************************************************/
+import { gameClock } from '../core/clock';
 function security_camera_wrapper(pixiSprite,x,y,maxswivel,minswivel){
     function jo_security_camera(x,y,maxswivel,minswivel){
         
@@ -93,13 +94,13 @@ function security_camera_wrapper(pixiSprite,x,y,maxswivel,minswivel){
                     this.sprite.texture = (img_security_camera_alerted);
                     this.target = {x:objectOfAlarm.x,y:objectOfAlarm.y};
                     
-                    //in 3 seconds, if this guard is still alive, alert the others.
-                    setTimeout(function(){
+                    //in 2 seconds, if this camera is still alive, alert the others.
+                    gameClock.after(2000, function(){
                         if(this.alive){
                             newMessage('All the other guards are on alert!');
                             alert_all_guards();
                         };
-                    }.bind(this), 2000);
+                    }.bind(this));
                 }
             
         };

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -3,6 +3,11 @@ Copyright 2014,2015, Jordan O'Leary, All rights reserved.
 If you would like to copy or use my code, you may contact
 me at jdoleary@gmail.com
 /*******************************************************/
+import { gameClock } from '../core/clock';
+import { events } from '../core/events';
+import { mouseMove, addKeyHandlers, removeHandlers } from '../systems/input';
+import { updateCamera } from '../systems/camera';
+import { updateParticles, shardParticleSplatter, bloodParticleSplatter, ejectShell } from '../systems/particles';
 ////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////
 /*
@@ -24,8 +29,6 @@ window.shell2 ??= undefined;
 window.shell3 ??= undefined;
 window.shell4 ??= undefined;
 window.shell5 ??= undefined;
-window.shell_speed = 10;
-window.blood_speed = 1;
 
 window.shellTextures = [];
 window.shellType = 2;
@@ -43,14 +46,6 @@ window.debug_on = false;
 
 function getColor(x,y){
     return {r:50,g:50,b:50,a:1};
-}
-function mouseMove(e){
-    //Viewport coords, not document coords: camera.getMouse wants the position within the
-    //canvas, and the canvas sits at the top-left of an unscrolled page. pageX/pageY add
-    //the scroll offset, which silently skewed aim whenever the page could scroll at all.
-    mouse_relative.x = e.clientX;
-    mouse_relative.y = e.clientY;
-
 }
 function windowSetup(){
     //Mr Doob's Stats.js:
@@ -340,11 +335,9 @@ function clearStage(){
             button = null;
         }
     }
-    //clear all timeouts
-    var id = window.setTimeout(function() {}, 0);
-    while (id--) {
-        window.clearTimeout(id); // will do nothing if no timeout with id is present
-    }
+    //Every gameplay delay lives on the GameClock now, so a restart is one call — the
+    //old version looped over every window timeout id to kill stray setTimeouts.
+    gameClock.clear();
 
     //removeHandlers:
     console.log('clear stage');
@@ -388,7 +381,13 @@ function startGame(){
     clearStage();
     
     state = states["Gameplay"];
-    
+
+    //fresh run, fresh clock: lastTimeStamp only advances during gameplay frames, so
+    //after a stay in the menu it is stale and would count the whole menu visit as one
+    //(clamped) catch-up burst.
+    lastTimeStamp = null;
+    step_accumulator = 0;
+
     //initialize variables:
     keys = {w: false, a: false, s: false, d: false, r: false, f: false, v: false, g:false, space:false, shift:false, LMB:false, RMB:false};
     stage_child = new PIXI.Container();//replaces stage for scaling
@@ -689,6 +688,19 @@ Animate Loop
 ////////////////////////////////////////////////////////////
 window.lastTimeStamp ??= undefined;
 window.deltaTime ??= undefined;
+//Fixed timestep (roadmap Phase 2). The simulation always steps in STEP_MS increments;
+//the render loop just decides how many steps to run to catch up to wall time. Movement,
+//bullets and particles are per-tick constants, so a fixed tick rate is what makes game
+//speed independent of the display's refresh rate (144 Hz no longer runs 2.4x fast, a
+//30 FPS cap no longer runs at half speed).
+window.STEP_MS = 1000/60;
+//Longest slice of wall time one frame is allowed to simulate. Returning to a
+//backgrounded tab (rAF stops entirely) would otherwise queue thousands of catch-up
+//steps — and a machine too slow to simulate in real time would fall further behind
+//every frame trying (the classic spiral of death). Beyond this cap the game slows
+//down instead of freezing.
+window.MAX_FRAME_MS = 250;
+window.step_accumulator = 0;
 function animate(time) {
     if(state == 0){
     }else if(state == 1){
@@ -696,23 +708,27 @@ function animate(time) {
         if(!lastTimeStamp) lastTimeStamp = time;
         deltaTime = time - lastTimeStamp;
         lastTimeStamp = time;
-        //console.log('delta: ' + deltaTime);
-        //console.log('time: ' + time);
-        
-        
+        if(deltaTime > MAX_FRAME_MS)deltaTime = MAX_FRAME_MS;
+
         stats.begin();//Mr Doob's Stats.js
-        if(!pause)gameloop(deltaTime);
+        if(!pause){
+            step_accumulator += deltaTime;
+            while(step_accumulator >= STEP_MS){
+                step_accumulator -= STEP_MS;
+                gameloop(STEP_MS);
+            }
+        }
         stats.end();//Mr Doob's Stats.js
-        
-        
+
+
     }
-    
+
     // render the stage
     renderer.render(stage);
     //request another animate call
-    requestAnimationFrame(animate);	
+    requestAnimationFrame(animate);
 
-    
+
 }
 
 
@@ -835,7 +851,7 @@ function gameloop_guards(deltaTime){
                             //if guard can't shoot yet (reaction time)
                             if(!guard.reacting){
                                 guard.reacting = true;
-                                setTimeout(reactionTimeout.bind(guard), guard.shoot_speed);
+                                gameClock.after(guard.shoot_speed, reactionTimeout.bind(guard));
                             }
                         }
                         
@@ -1250,136 +1266,6 @@ function gameloop_messages_and_tooltip(deltaTime){
         }
     }
 }
-function gameloop_zoom_and_camera(deltaTime){
-    //////////////////////
-    //Camera
-    //////////////////////
-    
- 
-    //////////////////////
-    //Zoom / Scale
-    //////////////////////
-    //this code allows the zoom / scale to change smoothly based on the mouse wheel input
-    
-   if(stage_child.scale.x < zoom - 0.05){//the 0.05 is close enough to desired value to stop so the zoom doesn't bounce back and forth.
-        stage_child.scale.x += zoom_magnitude;
-        stage_child.scale.y += zoom_magnitude;
-        changeFontSizes();
-    }else if(stage_child.scale.x > zoom + 0.05){//the 0.05 is close enough to desired value to stop so the zoom doesn't bounce back and forth.
-        stage_child.scale.x -= zoom_magnitude;
-        stage_child.scale.y -= zoom_magnitude;
-        changeFontSizes();
-    
-    }
-    
-    //loose camera
-    camera.x = hero.x + (mouse.x - hero.x)/look_sensitivity;
-    camera.y = hero.y + (mouse.y - hero.y)/look_sensitivity;
-    //don't let camera show out of bounds:
-    var cam_width = window_properties.width*(1/stage_child.scale.x);
-    var cam_height = window_properties.height*(1/stage_child.scale.y);
-    var cam_adjust_x = camera.x;
-    var cam_adjust_y = camera.y;
-    
-    
-    if(camera.x < 0+cam_width/2){
-        cam_adjust_x = 0+cam_width/2;
-    }
-    if(camera.y < 0+cam_height/2){
-        cam_adjust_y = 0+cam_height/2;
-    }
-    
-    if(camera.x >= grid_width-cam_width/2){
-        cam_adjust_x = grid_width-cam_width/2;
-    }
-    if(camera.y >= grid_height-cam_height/2){
-        cam_adjust_y = grid_height-cam_height/2;
-    }
-    
-    //check both:
-    if(cam_width > grid_width){
-        //if both out of left and right limit, put camera in middle
-        cam_adjust_x = grid_width/2;
-    }
-    if(cam_height > grid_height){
-        //if both out of top and bottom limit, put camera in middle
-        cam_adjust_y = grid_height/2;
-    }
-    
-    camera.x = cam_adjust_x;
-    camera.y = cam_adjust_y;
-    
-    
-    if(camera.shaking){
-        camera.posBeforeShakex = cam_adjust_x;
-        camera.posBeforeShakey = cam_adjust_y;    
-    }
-    camera.shake();
-    
-    
-    
-    /*
-    //The below commented block is for smooth camera
-    //press space to look around
-    if(keys['space']){
-        //camera floats between hero and mouse
-        //smooth camera
-        camera.following = true;
-        camera.target = {x: hero.x + (mouse.x - hero.x)/2, y: hero.y + (mouse.y - hero.y)/2};
-    }else{
-        //set camera target to hero
-        if(camera.following){
-            //return to hero
-            camera.target = hero;
-        }else{
-            //stick to hero
-            camera.x = hero.x; 
-            camera.y = hero.y;
-        }
-    }
-    //if the camera is set to following, move it to target, otherwise, don't because it is sticking to target.
-    if(camera.following && camera.move_to_target()){
-        if(camera.target == hero){
-            camera.following = false;//when camera reaches it's target, turn off following so it can just stick.
-        }
-    }*/
-    //set the stage_child to the correct position, the stage_child now acts as the camera.
-    //stage_child.x = (-camera.x+cam_width/2)*stage_child.scale.x;
-    //stage_child.y = (-camera.y+cam_height/2)*stage_child.scale.y;
-    //camera with kickback:
-    if(stage_child.kickx != null && stage_child.kicky != null){
-        var movement = moveToTarget(stage_child.kickx,stage_child.kicky,camera.x,camera.y,kickback_speed);
-        //set kickback to null if it reaches its target:
-        if(movement.x == camera.x && movement.y == camera.y){
-            stage_child.kickx = null;
-            stage_child.kicky = null;
-        }else{
-            //move kickback to where it should be:
-            stage_child.kickx = movement.x;
-            stage_child.kicky = movement.y;
-            stage_child.x = (-stage_child.kickx+cam_width/2)*stage_child.scale.x;
-            stage_child.y = (-stage_child.kicky+cam_height/2)*stage_child.scale.y;
-        }
-    }else{
-        //camera without kickback
-        stage_child.x = (-camera.x+cam_width/2)*stage_child.scale.x;
-        stage_child.y = (-camera.y+cam_height/2)*stage_child.scale.y;
-        
-    }
-    
-    
-}
-function scaleStageChild(a){
-    stage_child.scale.x = a;
-    stage_child.scale.y = a;
-    console.log(stage_child.x + "," + stage_child.y);
-    var cam_width = window_properties.width*(1/stage_child.scale.x);
-    var cam_height = window_properties.height*(1/stage_child.scale.y);
-    console.log(cam_width + "," + cam_height);
-}
-function changeFontSizes(){
-    tooltip.style.font = 30/stage_child.scale.x + "px Arial";      
-}
 function gameloop_getawaycar_and_loot(deltaTime){
     //////////////////////
     //Getaway Car and Loot
@@ -1737,6 +1623,12 @@ function make_starburst_without_limit(unit){
 
 function gameloop(deltaTime){
     //////////////////////
+    //advance gameplay timers (guard reactions, chokes, backup waves, ...).
+    //Ticked from the fixed step, so pause freezes every pending timer for free.
+    //////////////////////
+    gameClock.update(deltaTime);
+
+    //////////////////////
     //update Mouse
     //////////////////////
     if(mouse_relative.x != -10000)mouse = camera.getMouse(mouse_relative);//only set mouse position if the mouse is on the stage
@@ -1769,7 +1661,7 @@ function gameloop(deltaTime){
             hero.gun.ammo--;
             doGunShotEffects(hero, hero.gun.silenced);//plays sound and shows affects
             //kickback camera
-            kickback();
+            events.emit('camera:kickback');
             ejectShell(hero);
             hero.shoot();
             if(!hero.gun.silenced)unsilenced_gun();//make noise (not real sound, but noise for guards) which draws guards
@@ -1851,39 +1743,8 @@ function gameloop(deltaTime){
     //////////////////////
     //update particles
     //////////////////////
-    for(var i = 0; i < shells.length; i++){
-        if(tickParticle(shells[i],20,true)){
-            shells.splice(i,1);
-            i--;
-        }
-    }
-    for(var i = 0; i < shards.length; i++){
-        if(tickParticle(shards[i],20,true)){
-            shards.splice(i,1);
-            i--;
-        }
-    }
-    for(var i = 0; i < bloods.length; i++){
-        var blood = bloods[i];
-        //shrink blood particle:
-        blood.scale.x*=0.7;
-        blood.scale.y*=0.7;
-        
-        
-        var blood_x_mod = randomFloatWithBias2(-10,10);
-        var blood_y_mod = randomFloatWithBias2(-10,10);
-        var blood_size_mod = randomFloatWithBias2(1,blood.scale.y*20);
-        //var skip_blood_draw = randomIntFromInterval(0,3);
-        drawBloodTrail(blood.position.x+blood_x_mod,blood.position.y+blood_y_mod,blood_size_mod);
-        
-        //remove when done ticking
-        if(tickParticle(blood,7,false)){
-            bloods.splice(i,1);
-            i--;
-        }
-        
-    }
-    
+    updateParticles(deltaTime);
+
 
     
     
@@ -1983,7 +1844,7 @@ function gameloop(deltaTime){
         
     }
     
-    gameloop_zoom_and_camera(deltaTime);
+    updateCamera(deltaTime);
     //causing slowdown?
     if(debug_on)updateDebugInfo();
     
@@ -2034,408 +1895,6 @@ function updateDebugInfo(){
         "corner: " + screenCorner.x + "," + screenCorner.y + "<br>"
     );
 }
-//Controls the behavior of a particle during one game tick
-function tickParticle(particle,tick_max,bounce){
-    //particle should have .dy .dx .dr. and tick
-    particle.position.y += particle.dy;
-    //check the y to see if it has gone into a wall
-    if(grid.isWallSolid_coords(particle.position.x,particle.position.y)){
-        particle.position.y -= particle.dy*2;
-        particle.dy *= -1;
-    }
-    particle.position.x -= particle.dx;
-        //check the x to see if it has gone into a wall
-        if(grid.isWallSolid_coords(particle.position.x,particle.position.y)){
-            // if particle should bounce off walls
-            if(bounce){
-                    particle.position.x += particle.dx*2;
-                    particle.dx *= -1;
-            }else{
-                return true;
-            }
-        }
-    
-    particle.dx *= 0.9;
-    particle.dy *= 0.9;
-    particle.rotation += particle.dr;
-    particle.tick++;
-    //remove from array once it is done moving (OPTIMIZATION)
-    if(particle.tick > tick_max){
-        return true;//remove it from array
-    }
-    return false;
-}
-////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////
-/*
-Key Handlers
-*/
-////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////
-
-function addKeyHandlers(){
-    //override right click:
-    if (document.addEventListener) {
-        document.addEventListener('contextmenu', function(e){
-            e.preventDefault();
-        }, false);
-    } else {
-        (document as any).attachEvent('oncontextmenu', function() {
-            window.event.returnValue = false;
-        });
-    }
-    window.onkeydown = function(e){
-        //this function is called every frame that said key is down
-        var code = e.keyCode ? e.keyCode : e.which;
-        //keyinfo[code] = String.fromCharCode(code);
-        if(hero.alive){
-            /*
-            if(code == 49){hero.changeGun(0);}//key 1
-            if(code == 50){hero.changeGun(1);}//key 2
-            if(code == 51){hero.changeGun(2);}//key 3
-            if(code == 52){hero.changeGun(3);}//key 4
-            if(code == 53){hero.changeGun(4);}//key 5
-            if(code == 54){hero.changeGun(5);}//key 6
-            */
-            if(code == 87){keys['w'] = true;}
-            if(code == 65){keys['a'] = true;}
-            if(code == 83){keys['s'] = true;}
-            if(code == 68){keys['d'] = true;}
-            if(code == 80){
-                //key p
-                hero.spyglass_equipped = !hero.spyglass_equipped;
-                
-                if(hero.spyglass_equipped){
-                    hero.gunOut = false;
-                    if(!hero.gunOut)hero.gun_shot_line.graphics.clear();
-                    setHeroImage();
-                }
-            
-            }
-            if(code == 71){
-                // !keys['g'] makes it so that it will only be called once for a single press of the letter
-                if(!keys['g']){
-                    hero.gunOut = !hero.gunOut;
-                    if(!hero.gunOut)hero.gun_shot_line.graphics.clear();
-                    setHeroImage();
-                    
-                    if(hero.gunOut){
-                        hero.spyglass_equipped = false;
-                    }
-                }
-                keys['g'] = true;
-            }
-            /*if(code == 80){
-                //'p'
-                pause = !pause;
-            }*/
-            if(code == 82){
-                keys['r'] = true;
-                hero.reload();
-            }
-            if(code == 70){
-                //plant bomb
-                if(!keys['f'] && !bomb.sprite.visible){
-                
-                    if(hero.ability_remote_bomb){
-                        //remote bomb
-                        hero.moving = false;
-                        circProgBar.reset(hero.x,hero.y,1500,function(){
-                            plantBomb();
-                            bomb_tooltip.text = ("Press 'f' to detonate");
-                        });
-                        bombs_left--;
-                    }else if(hero.ability_timed_bomb){
-                        //timed bomb
-                        //if f isn't already pressed and bomb isn't already set
-                        if(bombs_left>0){
-                            hero.moving = false;
-                            circProgBar.reset(hero.x,hero.y,1500,function(){plantBomb();setBomb(5000);});
-                            bombs_left--;
-                        }else{
-                            newFloatingMessage("No Bombs Left",{x:hero.x,y:hero.y},"#FFaa00");
-                        }
-                    }
-                     
-                }
-                if(!keys['f'] && bomb.sprite.visible){
-                    if(hero.ability_remote_bomb){
-                        //set remote bomb
-                        setBomb(500);
-                    }
-                }
-                keys['f'] = true;
-            
-            }
-            if(code == 86){
-                // !keys['v'] makes it so that it will only be called once for a single press of the letter
-                if(!keys['v']){
-                    circProgBar.heroMaskProg(hero.ability_toggle_mask_speed,useMask,!hero.masked);
-                    
-                    
-                }
-                keys['v'] = true;
-            }
-            if(code == 16){
-                keys['shift'] = true;
-                //cannot sprint while dragging something
-                if(!hero_drag_target){
-                    hero.speed = hero.speed_sprint;
-                }
-            
-            }
-            if(code == 32){
-                keys['space'] = true;
-                if(!hero_drag_target){
-                    if(!grid.a_door_is_being_unlocked){
-                            //lockpick door:
-                    
-                        for(var i = 0; i < grid.doors.length; i++){
-                            var door = grid.doors[i];
-                            if(door.solid && get_distance(hero.x,hero.y,door.x+grid.cell_size/2,door.y+grid.cell_size/2) <= hero.radius*5){
-                                //if door isn't solid, then it is already unlocked.
-                                grid.a_door_is_being_unlocked = true;
-                                
-                                //timer
-                                var unlockTimeRemaining = hero.lockpick_speed;
-                                hero.lockpicking = true;
-                                circProgBar.reset(door.x+grid.cell_size/2,door.y+grid.cell_size/2,unlockTimeRemaining,grid.door_sprites[i].unlock.bind(grid.door_sprites[i]));
-                                //cancel unlocking if hero moves away from door, unless hero has unlocked remote unlock
-                                if(!hero.ability_remote_lockpick)circProgBar.distanceCancelTarget = {x:door.x,y:door.y};
-                                
-                                return;//unlocking doors succeeds loot interactions.  (Hero can unlock door while holding loot).
-                            }
-                        }
-                    
-                        //check if any dead guards are close enough to be dragged.
-                        for(var i = 0; i < guards.length; i++){
-                            var guard = guards[i];
-                            if(get_distance(hero.x,hero.y,guard.x,guard.y) <= hero.radius*dragDistance){
-                            
-                                //check if any dead guards are close enough to be dragged.
-                                if(!guard.alive){
-                                    //hero is dragging a dead body
-                                    
-                                    //slow down hero speed because he just started dragging something.
-                                    hero.speed = hero.speed/2;
-                                    hero_drag_target = guard;
-                                    hero_drag_target.speed = hero.speed;
-                                    hero_drag_target.stop_distance = hero.radius*2;//I don't know why but the stop distance here seems to need to be bigger by a factor of 10
-                                    //return;//don't return, this allows choking out a guard to have higher precedence than dragging a body
-                                }else{
-                                    //hero is choking out a live guard who is not already alarmed:
-                                    newMessage('You are choking out a guard!');
-                                    //play_sound(sound_guard_choke);
-                                            
-                                            
-                                    //add to stats:
-                                    jo_store_inc("guardsChoked");
-                                    
-                                    guard.moving = true;
-                                    guard.path = [];
-                                    guard.target = {x: null, y:null}; 
-                                    guard.being_choked_out = true;
-                                    //slow down hero speed because he just started dragging something.
-                                    hero.speed = hero.speed_walk/2;
-                                    hero_drag_target = guard;
-                                    hero_drag_target.speed = hero.speed;
-                                    hero_drag_target.stop_distance = hero.radius*2;//I don't know why but the stop distance here seems to need to be bigger by a factor of 10
-                                    setTimeout(function(){
-                                        //check that the guard is still being choked out, if not, he's not dead so don't kill() him
-                                        if(hero_drag_target == this){
-                                            newMessage('The guard is dispached!');
-                                            this.kill();
-                                            //if space isn't still being held release body:
-                                            if(!keys['space']){
-                                                //drag is a toggle action so release current drag target.
-                                                hero_drag_target.stop_dragging();
-                                                hero_drag_target = null;
-                                                //bring hero speed back to normal
-                                                hero.speed = hero.speed_walk;
-                                            }
-                                        }
-                                    }.bind(guard), hero.ability_choke_speed);
-                                    return;
-                                }
-
-                            }
-                            
-                                
-                            
-                        }
-                        
-                        //check if hero is close enough to bug a camera:
-                        for(var s = 0; s < security_cameras.length; s++){           
-                            var cam = security_cameras[s];
-                            if(hero.alive && get_distance(hero.x,hero.y,cam.x,cam.y) <= hero.radius*dragDistance){
-                                cam.hacked = true;
-                            }
-                        }
-                    
-                        //note: dragging guards takes precedence over all the following actions.
-                        
-                        //check if hero is close enough to the security camera computer to disable cameras:
-                        if(!cameras_disabled && get_distance(hero.x,hero.y,computer_for_security_cameras.x,computer_for_security_cameras .y) <= hero.radius*4){
-                            cameras_disabled = true;
-                            newMessage('All security cameras have been disabled!');
-                            computer_for_security_cameras.sprite.texture = (img_computer_off);
-                            for(var i = 0; i < security_cameras.length; i++){
-                                security_cameras[i].sprite.texture = (img_cam_off);
-                            
-                            }
-                        }
-                    }
-                    
-                }
-                
-            }
-        }
-        
-        if(code == 27){
-            //esc
-            startMenu();
-        }
-        
-        hero_move_animation_check();
-    };
-    window.onkeyup = function(e){
-        var code = e.keyCode ? e.keyCode : e.which;
-        if(code == 87){keys['w'] = false;}
-        if(code == 65){keys['a'] = false;}
-        if(code == 83){keys['s'] = false;}
-        if(code == 68){keys['d'] = false;}
-        if(code == 70){keys['f'] = false;}
-        if(code == 71){keys['g'] = false;}
-        if(code == 82){keys['r'] = false;}
-        if(code == 86){
-            //on release of key only
-            //if(keys['v'])circProgBar.stop();//stop putting on mask
-            keys['v'] = false;
-        }
-        if(code == 16){
-            keys['shift'] = false;
-            if(hero_drag_target==null){
-                hero.speed = hero.speed_walk;
-            }
-        }
-        if(code == 32){
-            keys['space'] = false;
-            //if hero was dragging something, drop it. (Don't drop a guard while he's being choked
-            if(hero_drag_target && !hero_drag_target.alive){
-                //drag is a toggle action so release current drag target.
-                hero_drag_target.stop_dragging();
-                hero_drag_target = null;
-                //bring hero speed back to normal
-                hero.speed = hero.speed_walk;
-            }
-            //allow user to abort unlocking door:
-            if(grid.a_door_is_being_unlocked && !hero.ability_remote_lockpick){
-                circProgBar.stop();
-                hero.lockpicking = false;
-            }
-            
-            grid.a_door_is_being_unlocked = false;//unlocking stops when space is released
-        }
-        hero_move_animation_check();
-        
-    };
-    // IE9, Chrome, Safari, Opera
-    window.addEventListener("mousewheel", mouseWheelHandler, false);
-    // Firefox
-    window.addEventListener("DOMMouseScroll", mouseWheelHandler, false);
-
-    onmousedown = function(e){
-        clickEvent = e;
-        if(clickEvent.which === 1){
-            //LMB
-            if(hero_drag_target){
-                newFloatingMessage("You cannot shoot while dragging a body!",{x:hero.x,y:hero.y},"#FFaa00");
-                return;
-            }
-            keys['LMB'] = true;
-            //hero can only shoot if gun is out
-            if(hero.gunOut){
-                    //very minor camera shake:
-                if(hero.gun.ammo > 0)camera.startShake(10,0);
-                
-                if(!hero.gun.automatic){
-                    if(hero.gun.ammo > 0){
-                        //very minor camera shake:
-                        camera.shakeDecay = 1.5;
-                    
-                        hero.gun.ammo--;
-                        //newFloatingMessage("Ammo: " + hero.gun.ammo + "/6",{x:hero.x,y:hero.y},"#FFaa00");
-                        doGunShotEffects(hero, hero.gun.silenced);//plays sound and shows affects
-                        //kickback camera
-                        kickback();
-                        ejectShell(hero);
-                        
-                        hero.shoot();
-                        if(!hero.gun.silenced)unsilenced_gun();//make noise (not real sound, but noise for guards) which draws guards
-                        window.mouse_click_obj = camera.objectivePoint_ignore_shake(clickEvent);  //uses clickEvent's .x and .y to find objective click
-                        
-                        
-                    }
-                }
-                if(hero.gun.ammo<=0){
-                    newFloatingMessage("Press 'r' to reload!",{x:hero.x,y:hero.y},"#FF0000");
-                    play_sound(sound_dry_fire);
-                }
-            }
-        }else if(clickEvent.which === 3){
-            //RMB
-            keys['RMB'] = true;
-            var oldgun = hero.gun;
-            for(var i = 0; i < gun_drops.length; i++){
-                var gun_drop = gun_drops[i];
-                //if close to gun_drop, pick it up:
-                if(get_distance(hero.x,hero.y,gun_drop.x,gun_drop.y) <= hero.radius*dragDistance){
-                    pickUpGunDrop(gun_drop);
-                    break;
-                }
-            }
-            if(oldgun != hero.gun){
-              // if hero picked up a gun:
-              drop_gun(oldgun,hero.x,hero.y);
-              setHeroImage(); 
-            }
-        }
-
-    }
-    onmouseup = function(e){
-        clickEvent = e;
-        if(clickEvent.which === 1){
-            keys['LMB'] = false;
-            //set shakeDecay so that when automatic gun is done firing it will stop the shake.
-            camera.shakeDecay = 1.5;
-        }else if(clickEvent.which === 3){
-            //RMB
-            keys['RMB'] = false;
-        }
-    }
-}
-function mouseWheelHandler(e){
-    // cross-browser wheel delta
-    var e = window.event || e; // old IE support
-    var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
-    
-    //limit amount that cam can zoom out
-    if(delta < 0 && zoom > 0.1){
-        zoom += delta * 0.05;
-    }else if (delta >0){
-        zoom += delta * 0.05;
-    }
-}
-function removeHandlers(excludeKeyHandlers?){
-    keys = {w: false, a: false, s: false, d: false, r: false, f: false, v: false, g:false, space:false, shift:false, LMB:false};
-    
-    //if excludeKeyDown is true, don't remove the onkeydown and onkeyup listeners
-    if(!excludeKeyHandlers)window.onkeydown = null;
-    if(!excludeKeyHandlers)window.onkeyup = null;
-    window.removeEventListener("mousewheel",mouseWheelHandler);
-    window.removeEventListener("DOMMouseScroll",mouseWheelHandler);
-    onmousedown = null;
-}
 ////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////
 /*
@@ -2469,7 +1928,7 @@ function spawn_backup(){
     newMessage("The police have arrived!");
     
     for(var backup = 0; backup < numOfBackupGuards; backup++){
-        setTimeout(spawn_individual_backup,1000*backup);//wait an extra second for each guard
+        gameClock.after(1000*backup, spawn_individual_backup);//wait an extra second for each guard
     }
 }
 function spawn_individual_backup(){
@@ -2602,20 +2061,6 @@ function doGunShotEffects(unit, silenced){
         play_sound_many(sound_gun_shots);
     }
 }
-window.hero_moving = false;
-function hero_move_animation_check(){
-        var hero_was = hero_moving;
-        if(keys['w'] || keys['a'] || keys['s'] || keys['d'])hero_moving = true;
-        else hero_moving = false;
-        if(hero_moving && !hero_was){
-            hero.feet_clip.gotoAndPlay(0);
-            hero.sprite_animate = true;
-        }
-        if(!hero_moving){
-            hero.feet_clip.gotoAndStop(0);
-            hero.sprite_animate = false;
-        }
-}
 
 //show alert icon
 function set_latestAlert(unit){
@@ -2628,11 +2073,11 @@ function set_latestAlert(unit){
             alert_clip.sprite.gotoAndPlay(0);
             
             //turn off the alert after 3.5 second
-            setTimeout(function(){
-                
+            gameClock.after(3500, function(){
+
                 alert_clip.sprite.visible = false;
 
-            }, 3500);
+            });
         }
     }
     
@@ -2794,118 +2239,6 @@ window.onresize = function (event){
 
 
 }
-window.shard_limit = 2000;
-window.shardType = 0;
-//Shart images inited at images_from_sheet.js
-function shardParticleSplatter(angle,target){
-    var shardAmount = randomIntFromInterval(6,30);
-        angle += Math.PI/2;//I don't know why it's off by Pi/2 but it is.
-    for(var i = 0; i < shardAmount; i++){
-        //make new bunnies
-        window.shard = new PIXI.Sprite(currentShard);
-        //shard = new PIXI.Sprite(img_shell);
-        
-        
-        shard.anchor.x = 0.5;
-        shard.anchor.y = 0.5;
-        shard.position.x = target.x;
-        shard.position.y = target.y;
-        var randScale = randomFloatFromInterval(0.3,1);
-        shard.scale.x = randScale;
-        shard.scale.y = randScale;
-        var randSpeed = randomFloatWithBias(0.1,shell_speed*2);
-        var randRotationOffset = randomFloatFromInterval(-Math.PI/6,Math.PI/6);
-        shard.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
-        shard.dx = randSpeed*Math.sin(angle+randRotationOffset);
-        shard.dy = randSpeed*Math.cos(angle+randRotationOffset);
-        shard.tick = 0;//the amount of times that it has moved;
-        shard.rotation = (angle);
-
-        shards.push(shard);
-        particle_container.addChild(shard);
-        
-        //rotate to next image:
-        shardType++
-        shardType %= shardImages.length;
-        window.currentShard = shardImages[shardType];
-        
-        if(shards.length > shard_limit)return;
-    }
-    
-}
-function bloodParticleSplatter(angle,target){
-    //var bloodAmount = randomIntFromInterval(15,30);
-    var bloodAmount = randomIntFromInterval(30,60);
-    angle += Math.PI/2;//I don't know why it's off by Pi/2 but it is.    
-    var bloodSplat;
-    for(var i = 0; i < bloodAmount; i++){
-        //make new bunnies
-        bloodSplat = new PIXI.Sprite();
-        
-        
-        bloodSplat.anchor.x = 0.5;
-        bloodSplat.anchor.y = 0.5;
-        /*var randScale = randomFloatFromInterval(1,2);
-        bloodSplat.scale.x = randScale;
-        bloodSplat.scale.y = randScale;*/
-        var randSpeed = randomFloatWithBias(0.7,blood_speed);
-        var randRotationOffset = randomFloatWithBias(0,Math.PI/4);
-        var negativeRotationOffset = randomIntFromInterval(0,2);
-        if(negativeRotationOffset)randRotationOffset *= -1;
-        bloodSplat.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
-        bloodSplat.dx = -randSpeed*Math.sin(angle+randRotationOffset)*15;
-        bloodSplat.dy = -randSpeed*Math.cos(angle+randRotationOffset)*15;
-        //start the blood off a little away from target
-        bloodSplat.position.x = target.x+Math.sin(angle)*20;
-        bloodSplat.position.y = target.y+Math.cos(angle)*20;
-        bloodSplat.tick = 0;//the amount of times that it has moved;
-        bloodSplat.rotation = (angle);
-
-        bloods.push(bloodSplat);
-    }
-    
-}
-function ejectShell(source){
-    
-    //make new bunnies
-    window.shell = new PIXI.Sprite(img_shell);
-    
-    
-    shell.anchor.x = 0.5;
-    shell.anchor.y = 0.5;
-    shell.position.x = source.x;
-    shell.position.y = source.y;
-    shell.scale.x = 0.5;
-    shell.scale.y = 0.5;
-    var randSpeed = randomFloatWithBias(shell_speed*0.6,shell_speed*2);
-    var randRotationOffset = randomFloatFromInterval(-Math.PI/6,Math.PI/6);
-    shell.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
-    shell.dx = randSpeed*Math.sin(source.sprite.rotation+randRotationOffset);
-    shell.dy = randSpeed*Math.cos(source.sprite.rotation+randRotationOffset);
-    shell.tick = 0;//the amount of times that it has moved;
-    shell.rotation = (source.sprite.rotation);
-
-    shells.push(shell);
-    particle_container.addChild(shell);
-    //cycle shell texture
-	/*shellType++
-	shellType %= 5;
-	currentTexture = shellTextures[shellType];*/
-    //
-}
-window.kickback_speed = 5;
-window.kickback_amount = 30;
-function kickback(){
-    var d = get_distance(hero.x,hero.y,mouse.x,mouse.y);
-    var kickback_mod = randomFloatFromInterval(0,20);
-    var c = kickback_amount+kickback_mod;
-    var xx = -(c/d)*(mouse.x-hero.x);
-    var yy = -(c/d)*(mouse.y - hero.y);
-    //set stage_child kickx so that the camera will kick back
-    stage_child.kickx = xx+camera.x;
-    stage_child.kicky = yy+camera.y;
-
-}
 /*Get map from server:*/
 window.map_json = "";
 function getMapInfo(subdir, fileName){
@@ -2959,6 +2292,6 @@ function getMapInfo(subdir, fileName){
 // `window`. It is an ES module now, so the functions below are republished as
 // globals for the not-yet-extracted code that still reads them by bare name.
 // See src/legacy-bridge.ts. Each extraction deletes another line from here.
-Object.assign(window, { getColor, mouseMove, windowSetup, fullscreen, drawBloodTrail, bakeBloodTrail, getUrlVars, removeAllChildren, clearStage, startMenu, startGame, setup_map, animate, reactionTimeout, gameloop_guards, gameloop_security_cams, gameloop_bullets, gameloop_doors, gameloop_dragtarget, gameloop_messages_and_tooltip, gameloop_zoom_and_camera, scaleStageChild, changeFontSizes, gameloop_getawaycar_and_loot, gameloop_alert_animation, pickUpGunDrop, make_starburst, make_starburst_with_modified_view, make_starburst_without_limit, gameloop, updateDebugInfo, tickParticle, addKeyHandlers, mouseWheelHandler, removeHandlers, newMessage, newFloatingMessage, updateMessage, spawn_backup, spawn_individual_backup, alert_all_guards, unsilenced_gun, setHeroImage, useMask, hero_is_dead, doGunShotEffects, hero_move_animation_check, set_latestAlert, setBomb, gameloop_bomb, explodeBomb, plantBomb, drop_gun, killHero, shardParticleSplatter, bloodParticleSplatter, ejectShell, kickback, getMapInfo });
+Object.assign(window, { getColor, windowSetup, fullscreen, drawBloodTrail, bakeBloodTrail, getUrlVars, removeAllChildren, clearStage, startMenu, startGame, setup_map, animate, reactionTimeout, gameloop_guards, gameloop_security_cams, gameloop_bullets, gameloop_doors, gameloop_dragtarget, gameloop_messages_and_tooltip, gameloop_getawaycar_and_loot, gameloop_alert_animation, pickUpGunDrop, make_starburst, make_starburst_with_modified_view, make_starburst_without_limit, gameloop, updateDebugInfo, newMessage, newFloatingMessage, updateMessage, spawn_backup, spawn_individual_backup, alert_all_guards, unsilenced_gun, setHeroImage, useMask, hero_is_dead, doGunShotEffects, set_latestAlert, setBomb, gameloop_bomb, explodeBomb, plantBomb, drop_gun, killHero, getMapInfo });
 
 export {};

--- a/src/legacy/sprite_guard.ts
+++ b/src/legacy/sprite_guard.ts
@@ -3,6 +3,7 @@ Copyright 2014,2015, Jordan O'Leary, All rights reserved.
 If you would like to copy or use my code, you may contact
 me at jdoleary@gmail.com
 /*******************************************************/
+import { gameClock } from '../core/clock';
 function sprite_guard_wrapper(pixiSprite, hasRiotShield){
     function sprite_guard(hasRiotShield){
         this.path = [];//path applies to AI following a path;
@@ -28,7 +29,7 @@ function sprite_guard_wrapper(pixiSprite, hasRiotShield){
         //Patrol repath throttling.
         //Without this, a guard with an empty path runs a full A* every single frame, and a
         //destination inside a sealed room (which never yields a path) makes that loop forever.
-        this.patrolRetryAt = 0;//timestamp (ms) before which getRandomPatrolPath() is a no-op
+        this.patrolRetryAt = 0;//gameClock time (ms) before which getRandomPatrolPath() is a no-op
         this.patrolFailStreak = 0;//consecutive searches that returned no path, drives the backoff
 
         //Add all sprites to sprite container
@@ -77,7 +78,8 @@ function sprite_guard_wrapper(pixiSprite, hasRiotShield){
         this.getRandomPatrolPath = function(){
             //finds a path to patrol
 
-            var now = performance.now();
+            //game time, not wall time: the backoff must not burn down while paused
+            var now = gameClock.now();
             //throttled: too soon since the last search (or still backing off from a failure)
             if(now < this.patrolRetryAt)return;
 
@@ -134,20 +136,20 @@ function sprite_guard_wrapper(pixiSprite, hasRiotShield){
                 // Guards don't react instantly, they need a second to comprehend what they saw
                 // This prevents shield guards from pulling out their shield the moment they see you
                 this.alarmedPre = true;
-                setTimeout(() => {
+                gameClock.after(this.reactionTimeMillis, () => {
                     this.becomeAlarmed()
-                    
+
                     this.path = [];//empty path
                     this.moving = false;//this sprite stop in their tracks when they see otherSprite.
-                    
-                    //in 3 seconds, if this guard is still alive, alert the others.
-                    setTimeout(function(){
+
+                    //in 2 seconds, if this guard is still alive, alert the others.
+                    gameClock.after(2000, function(){
                         if(this.alive && !this.being_choked_out){
                             newMessage('All the other guards are on alert!');
                             alert_all_guards();
                         };
-                    }.bind(this), 2000);
-                }, this.reactionTimeMillis)
+                    }.bind(this));
+                })
             }
 
             

--- a/src/legacy/sprite_hero.ts
+++ b/src/legacy/sprite_hero.ts
@@ -3,6 +3,9 @@ Copyright 2014,2015, Jordan O'Leary, All rights reserved.
 If you would like to copy or use my code, you may contact
 me at jdoleary@gmail.com
 /*******************************************************/
+import { gameClock } from '../core/clock';
+import { removeHandlers } from '../systems/input';
+import { bloodParticleSplatter } from '../systems/particles';
 function sprite_hero_wrapper(pixiSprite,speed_walk,speed_sprint){
     function sprite_hero(){
         this.speed_walk = speed_walk;
@@ -128,7 +131,7 @@ function sprite_hero_wrapper(pixiSprite,speed_walk,speed_sprint){
         this.setLastSeen = function(observer){
             if(observer){
                 //if the observer is still alive after 2 seconds and not being choked out, alert the others
-                setTimeout(function(){
+                gameClock.after(2000, function(){
                     if(observer.alive && !observer.being_choked_out){
                         if(this.lastSeenX != observer.sawHeroLastAt.x && this.lastSeenY != observer.sawHeroLastAt.y){
                             this.lastSeenX = observer.sawHeroLastAt.x;
@@ -140,7 +143,7 @@ function sprite_hero_wrapper(pixiSprite,speed_walk,speed_sprint){
                             //newMessage("Last seen " + observer.sawHeroLastAt.x + "," + observer.sawHeroLastAt.y);
                         }
                     };
-                }.bind(this), 2000);
+                }.bind(this));
             }else{
                 //if observer is null, everyone is notified immediately (gunshot or camera or something).
                 if(this.lastSeenX != this.x && this.lastSeenY != this.y){

--- a/src/systems/camera.ts
+++ b/src/systems/camera.ts
@@ -1,0 +1,122 @@
+/**
+ * Camera system (roadmap §2.2 strangler step, Phase 2).
+ *
+ * Owns the per-frame camera: smooth zoom, the loose mouse-led follow, map-edge
+ * clamping, shake, and shot kickback. Moved verbatim out of main.ts; still reads
+ * the shared world state (`camera`, `stage_child`, `hero`, `mouse`, ...) as window
+ * globals until those gain owners of their own.
+ *
+ * Kickback arrives over the event bus ('camera:kickback') rather than by direct
+ * call — the first use of the FX seam the later phases build on.
+ */
+import { events } from '../core/events';
+
+//Tuning constants. Only this module reads them (they were window globals in main.ts).
+var kickback_speed = 5;
+var kickback_amount = 30;
+
+export function updateCamera(deltaTime){
+    //////////////////////
+    //Zoom / Scale
+    //////////////////////
+    //this code allows the zoom / scale to change smoothly based on the mouse wheel input
+
+   if(stage_child.scale.x < zoom - 0.05){//the 0.05 is close enough to desired value to stop so the zoom doesn't bounce back and forth.
+        stage_child.scale.x += zoom_magnitude;
+        stage_child.scale.y += zoom_magnitude;
+        changeFontSizes();
+    }else if(stage_child.scale.x > zoom + 0.05){//the 0.05 is close enough to desired value to stop so the zoom doesn't bounce back and forth.
+        stage_child.scale.x -= zoom_magnitude;
+        stage_child.scale.y -= zoom_magnitude;
+        changeFontSizes();
+
+    }
+
+    //loose camera
+    camera.x = hero.x + (mouse.x - hero.x)/look_sensitivity;
+    camera.y = hero.y + (mouse.y - hero.y)/look_sensitivity;
+    //don't let camera show out of bounds:
+    var cam_width = window_properties.width*(1/stage_child.scale.x);
+    var cam_height = window_properties.height*(1/stage_child.scale.y);
+    var cam_adjust_x = camera.x;
+    var cam_adjust_y = camera.y;
+
+
+    if(camera.x < 0+cam_width/2){
+        cam_adjust_x = 0+cam_width/2;
+    }
+    if(camera.y < 0+cam_height/2){
+        cam_adjust_y = 0+cam_height/2;
+    }
+
+    if(camera.x >= grid_width-cam_width/2){
+        cam_adjust_x = grid_width-cam_width/2;
+    }
+    if(camera.y >= grid_height-cam_height/2){
+        cam_adjust_y = grid_height-cam_height/2;
+    }
+
+    //check both:
+    if(cam_width > grid_width){
+        //if both out of left and right limit, put camera in middle
+        cam_adjust_x = grid_width/2;
+    }
+    if(cam_height > grid_height){
+        //if both out of top and bottom limit, put camera in middle
+        cam_adjust_y = grid_height/2;
+    }
+
+    camera.x = cam_adjust_x;
+    camera.y = cam_adjust_y;
+
+
+    if(camera.shaking){
+        camera.posBeforeShakex = cam_adjust_x;
+        camera.posBeforeShakey = cam_adjust_y;
+    }
+    camera.shake();
+
+
+    //camera with kickback:
+    if(stage_child.kickx != null && stage_child.kicky != null){
+        var movement = moveToTarget(stage_child.kickx,stage_child.kicky,camera.x,camera.y,kickback_speed);
+        //set kickback to null if it reaches its target:
+        if(movement.x == camera.x && movement.y == camera.y){
+            stage_child.kickx = null;
+            stage_child.kicky = null;
+        }else{
+            //move kickback to where it should be:
+            stage_child.kickx = movement.x;
+            stage_child.kicky = movement.y;
+            stage_child.x = (-stage_child.kickx+cam_width/2)*stage_child.scale.x;
+            stage_child.y = (-stage_child.kicky+cam_height/2)*stage_child.scale.y;
+        }
+    }else{
+        //camera without kickback
+        stage_child.x = (-camera.x+cam_width/2)*stage_child.scale.x;
+        stage_child.y = (-camera.y+cam_height/2)*stage_child.scale.y;
+
+    }
+
+
+}
+
+function changeFontSizes(){
+    tooltip.style.font = 30/stage_child.scale.x + "px Arial";
+}
+
+//Punch the camera back away from the muzzle when the hero fires.
+function kickback(){
+    var d = get_distance(hero.x,hero.y,mouse.x,mouse.y);
+    var kickback_mod = randomFloatFromInterval(0,20);
+    var c = kickback_amount+kickback_mod;
+    var xx = -(c/d)*(mouse.x-hero.x);
+    var yy = -(c/d)*(mouse.y - hero.y);
+    //set stage_child kickx so that the camera will kick back
+    stage_child.kickx = xx+camera.x;
+    stage_child.kicky = yy+camera.y;
+
+}
+
+//FX seam: shooters announce the shot; the camera decides what to do about it.
+events.on('camera:kickback', kickback);

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -1,0 +1,403 @@
+/**
+ * Input system (roadmap §2.2 strangler step, Phase 2).
+ *
+ * Owns the raw DOM handlers: keyboard state, mouse buttons, wheel zoom, and the
+ * gameplay actions bound directly to them (interact, bomb, mask, drag/choke, ...).
+ * Moved verbatim out of main.ts; still reads the shared world state (`hero`,
+ * `keys`, `grid`, ...) as window globals until those gain owners of their own.
+ *
+ * The one behavioural dependency taken as an import is the GameClock: the choke
+ * countdown used to be a raw setTimeout that kept running while paused.
+ */
+import { gameClock } from '../core/clock';
+import { events } from '../core/events';
+import { ejectShell } from './particles';
+
+export function mouseMove(e){
+    //Viewport coords, not document coords: camera.getMouse wants the position within the
+    //canvas, and the canvas sits at the top-left of an unscrolled page. pageX/pageY add
+    //the scroll offset, which silently skewed aim whenever the page could scroll at all.
+    mouse_relative.x = e.clientX;
+    mouse_relative.y = e.clientY;
+
+}
+
+export function addKeyHandlers(){
+    //override right click:
+    if (document.addEventListener) {
+        document.addEventListener('contextmenu', function(e){
+            e.preventDefault();
+        }, false);
+    } else {
+        (document as any).attachEvent('oncontextmenu', function() {
+            window.event.returnValue = false;
+        });
+    }
+    window.onkeydown = function(e){
+        //this function is called every frame that said key is down
+        var code = e.keyCode ? e.keyCode : e.which;
+        //keyinfo[code] = String.fromCharCode(code);
+        if(hero.alive){
+            /*
+            if(code == 49){hero.changeGun(0);}//key 1
+            if(code == 50){hero.changeGun(1);}//key 2
+            if(code == 51){hero.changeGun(2);}//key 3
+            if(code == 52){hero.changeGun(3);}//key 4
+            if(code == 53){hero.changeGun(4);}//key 5
+            if(code == 54){hero.changeGun(5);}//key 6
+            */
+            if(code == 87){keys['w'] = true;}
+            if(code == 65){keys['a'] = true;}
+            if(code == 83){keys['s'] = true;}
+            if(code == 68){keys['d'] = true;}
+            if(code == 80){
+                //key p
+                hero.spyglass_equipped = !hero.spyglass_equipped;
+
+                if(hero.spyglass_equipped){
+                    hero.gunOut = false;
+                    if(!hero.gunOut)hero.gun_shot_line.graphics.clear();
+                    setHeroImage();
+                }
+
+            }
+            if(code == 71){
+                // !keys['g'] makes it so that it will only be called once for a single press of the letter
+                if(!keys['g']){
+                    hero.gunOut = !hero.gunOut;
+                    if(!hero.gunOut)hero.gun_shot_line.graphics.clear();
+                    setHeroImage();
+
+                    if(hero.gunOut){
+                        hero.spyglass_equipped = false;
+                    }
+                }
+                keys['g'] = true;
+            }
+            /*if(code == 80){
+                //'p'
+                pause = !pause;
+            }*/
+            if(code == 82){
+                keys['r'] = true;
+                hero.reload();
+            }
+            if(code == 70){
+                //plant bomb
+                if(!keys['f'] && !bomb.sprite.visible){
+
+                    if(hero.ability_remote_bomb){
+                        //remote bomb
+                        hero.moving = false;
+                        circProgBar.reset(hero.x,hero.y,1500,function(){
+                            plantBomb();
+                            bomb_tooltip.text = ("Press 'f' to detonate");
+                        });
+                        bombs_left--;
+                    }else if(hero.ability_timed_bomb){
+                        //timed bomb
+                        //if f isn't already pressed and bomb isn't already set
+                        if(bombs_left>0){
+                            hero.moving = false;
+                            circProgBar.reset(hero.x,hero.y,1500,function(){plantBomb();setBomb(5000);});
+                            bombs_left--;
+                        }else{
+                            newFloatingMessage("No Bombs Left",{x:hero.x,y:hero.y},"#FFaa00");
+                        }
+                    }
+
+                }
+                if(!keys['f'] && bomb.sprite.visible){
+                    if(hero.ability_remote_bomb){
+                        //set remote bomb
+                        setBomb(500);
+                    }
+                }
+                keys['f'] = true;
+
+            }
+            if(code == 86){
+                // !keys['v'] makes it so that it will only be called once for a single press of the letter
+                if(!keys['v']){
+                    circProgBar.heroMaskProg(hero.ability_toggle_mask_speed,useMask,!hero.masked);
+
+
+                }
+                keys['v'] = true;
+            }
+            if(code == 16){
+                keys['shift'] = true;
+                //cannot sprint while dragging something
+                if(!hero_drag_target){
+                    hero.speed = hero.speed_sprint;
+                }
+
+            }
+            if(code == 32){
+                keys['space'] = true;
+                if(!hero_drag_target){
+                    if(!grid.a_door_is_being_unlocked){
+                            //lockpick door:
+
+                        for(var i = 0; i < grid.doors.length; i++){
+                            var door = grid.doors[i];
+                            if(door.solid && get_distance(hero.x,hero.y,door.x+grid.cell_size/2,door.y+grid.cell_size/2) <= hero.radius*5){
+                                //if door isn't solid, then it is already unlocked.
+                                grid.a_door_is_being_unlocked = true;
+
+                                //timer
+                                var unlockTimeRemaining = hero.lockpick_speed;
+                                hero.lockpicking = true;
+                                circProgBar.reset(door.x+grid.cell_size/2,door.y+grid.cell_size/2,unlockTimeRemaining,grid.door_sprites[i].unlock.bind(grid.door_sprites[i]));
+                                //cancel unlocking if hero moves away from door, unless hero has unlocked remote unlock
+                                if(!hero.ability_remote_lockpick)circProgBar.distanceCancelTarget = {x:door.x,y:door.y};
+
+                                return;//unlocking doors succeeds loot interactions.  (Hero can unlock door while holding loot).
+                            }
+                        }
+
+                        //check if any dead guards are close enough to be dragged.
+                        for(var i = 0; i < guards.length; i++){
+                            var guard = guards[i];
+                            if(get_distance(hero.x,hero.y,guard.x,guard.y) <= hero.radius*dragDistance){
+
+                                //check if any dead guards are close enough to be dragged.
+                                if(!guard.alive){
+                                    //hero is dragging a dead body
+
+                                    //slow down hero speed because he just started dragging something.
+                                    hero.speed = hero.speed/2;
+                                    hero_drag_target = guard;
+                                    hero_drag_target.speed = hero.speed;
+                                    hero_drag_target.stop_distance = hero.radius*2;//I don't know why but the stop distance here seems to need to be bigger by a factor of 10
+                                    //return;//don't return, this allows choking out a guard to have higher precedence than dragging a body
+                                }else{
+                                    //hero is choking out a live guard who is not already alarmed:
+                                    newMessage('You are choking out a guard!');
+                                    //play_sound(sound_guard_choke);
+
+
+                                    //add to stats:
+                                    jo_store_inc("guardsChoked");
+
+                                    guard.moving = true;
+                                    guard.path = [];
+                                    guard.target = {x: null, y:null};
+                                    guard.being_choked_out = true;
+                                    //slow down hero speed because he just started dragging something.
+                                    hero.speed = hero.speed_walk/2;
+                                    hero_drag_target = guard;
+                                    hero_drag_target.speed = hero.speed;
+                                    hero_drag_target.stop_distance = hero.radius*2;//I don't know why but the stop distance here seems to need to be bigger by a factor of 10
+                                    gameClock.after(hero.ability_choke_speed, function(){
+                                        //check that the guard is still being choked out, if not, he's not dead so don't kill() him
+                                        if(hero_drag_target == this){
+                                            newMessage('The guard is dispached!');
+                                            this.kill();
+                                            //if space isn't still being held release body:
+                                            if(!keys['space']){
+                                                //drag is a toggle action so release current drag target.
+                                                hero_drag_target.stop_dragging();
+                                                hero_drag_target = null;
+                                                //bring hero speed back to normal
+                                                hero.speed = hero.speed_walk;
+                                            }
+                                        }
+                                    }.bind(guard));
+                                    return;
+                                }
+
+                            }
+
+
+
+                        }
+
+                        //check if hero is close enough to bug a camera:
+                        for(var s = 0; s < security_cameras.length; s++){
+                            var cam = security_cameras[s];
+                            if(hero.alive && get_distance(hero.x,hero.y,cam.x,cam.y) <= hero.radius*dragDistance){
+                                cam.hacked = true;
+                            }
+                        }
+
+                        //note: dragging guards takes precedence over all the following actions.
+
+                        //check if hero is close enough to the security camera computer to disable cameras:
+                        if(!cameras_disabled && get_distance(hero.x,hero.y,computer_for_security_cameras.x,computer_for_security_cameras .y) <= hero.radius*4){
+                            cameras_disabled = true;
+                            newMessage('All security cameras have been disabled!');
+                            computer_for_security_cameras.sprite.texture = (img_computer_off);
+                            for(var i = 0; i < security_cameras.length; i++){
+                                security_cameras[i].sprite.texture = (img_cam_off);
+
+                            }
+                        }
+                    }
+
+                }
+
+            }
+        }
+
+        if(code == 27){
+            //esc
+            startMenu();
+        }
+
+        hero_move_animation_check();
+    };
+    window.onkeyup = function(e){
+        var code = e.keyCode ? e.keyCode : e.which;
+        if(code == 87){keys['w'] = false;}
+        if(code == 65){keys['a'] = false;}
+        if(code == 83){keys['s'] = false;}
+        if(code == 68){keys['d'] = false;}
+        if(code == 70){keys['f'] = false;}
+        if(code == 71){keys['g'] = false;}
+        if(code == 82){keys['r'] = false;}
+        if(code == 86){
+            //on release of key only
+            //if(keys['v'])circProgBar.stop();//stop putting on mask
+            keys['v'] = false;
+        }
+        if(code == 16){
+            keys['shift'] = false;
+            if(hero_drag_target==null){
+                hero.speed = hero.speed_walk;
+            }
+        }
+        if(code == 32){
+            keys['space'] = false;
+            //if hero was dragging something, drop it. (Don't drop a guard while he's being choked
+            if(hero_drag_target && !hero_drag_target.alive){
+                //drag is a toggle action so release current drag target.
+                hero_drag_target.stop_dragging();
+                hero_drag_target = null;
+                //bring hero speed back to normal
+                hero.speed = hero.speed_walk;
+            }
+            //allow user to abort unlocking door:
+            if(grid.a_door_is_being_unlocked && !hero.ability_remote_lockpick){
+                circProgBar.stop();
+                hero.lockpicking = false;
+            }
+
+            grid.a_door_is_being_unlocked = false;//unlocking stops when space is released
+        }
+        hero_move_animation_check();
+
+    };
+    // IE9, Chrome, Safari, Opera
+    window.addEventListener("mousewheel", mouseWheelHandler, false);
+    // Firefox
+    window.addEventListener("DOMMouseScroll", mouseWheelHandler, false);
+
+    onmousedown = function(e){
+        clickEvent = e;
+        if(clickEvent.which === 1){
+            //LMB
+            if(hero_drag_target){
+                newFloatingMessage("You cannot shoot while dragging a body!",{x:hero.x,y:hero.y},"#FFaa00");
+                return;
+            }
+            keys['LMB'] = true;
+            //hero can only shoot if gun is out
+            if(hero.gunOut){
+                    //very minor camera shake:
+                if(hero.gun.ammo > 0)camera.startShake(10,0);
+
+                if(!hero.gun.automatic){
+                    if(hero.gun.ammo > 0){
+                        //very minor camera shake:
+                        camera.shakeDecay = 1.5;
+
+                        hero.gun.ammo--;
+                        //newFloatingMessage("Ammo: " + hero.gun.ammo + "/6",{x:hero.x,y:hero.y},"#FFaa00");
+                        doGunShotEffects(hero, hero.gun.silenced);//plays sound and shows affects
+                        //kickback camera
+                        events.emit('camera:kickback');
+                        ejectShell(hero);
+
+                        hero.shoot();
+                        if(!hero.gun.silenced)unsilenced_gun();//make noise (not real sound, but noise for guards) which draws guards
+                        window.mouse_click_obj = camera.objectivePoint_ignore_shake(clickEvent);  //uses clickEvent's .x and .y to find objective click
+
+
+                    }
+                }
+                if(hero.gun.ammo<=0){
+                    newFloatingMessage("Press 'r' to reload!",{x:hero.x,y:hero.y},"#FF0000");
+                    play_sound(sound_dry_fire);
+                }
+            }
+        }else if(clickEvent.which === 3){
+            //RMB
+            keys['RMB'] = true;
+            var oldgun = hero.gun;
+            for(var i = 0; i < gun_drops.length; i++){
+                var gun_drop = gun_drops[i];
+                //if close to gun_drop, pick it up:
+                if(get_distance(hero.x,hero.y,gun_drop.x,gun_drop.y) <= hero.radius*dragDistance){
+                    pickUpGunDrop(gun_drop);
+                    break;
+                }
+            }
+            if(oldgun != hero.gun){
+              // if hero picked up a gun:
+              drop_gun(oldgun,hero.x,hero.y);
+              setHeroImage();
+            }
+        }
+
+    }
+    onmouseup = function(e){
+        clickEvent = e;
+        if(clickEvent.which === 1){
+            keys['LMB'] = false;
+            //set shakeDecay so that when automatic gun is done firing it will stop the shake.
+            camera.shakeDecay = 1.5;
+        }else if(clickEvent.which === 3){
+            //RMB
+            keys['RMB'] = false;
+        }
+    }
+}
+function mouseWheelHandler(e){
+    // cross-browser wheel delta
+    var e = window.event || e; // old IE support
+    var delta = Math.max(-1, Math.min(1, (e.wheelDelta || -e.detail)));
+
+    //limit amount that cam can zoom out
+    if(delta < 0 && zoom > 0.1){
+        zoom += delta * 0.05;
+    }else if (delta >0){
+        zoom += delta * 0.05;
+    }
+}
+export function removeHandlers(excludeKeyHandlers?){
+    keys = {w: false, a: false, s: false, d: false, r: false, f: false, v: false, g:false, space:false, shift:false, LMB:false};
+
+    //if excludeKeyDown is true, don't remove the onkeydown and onkeyup listeners
+    if(!excludeKeyHandlers)window.onkeydown = null;
+    if(!excludeKeyHandlers)window.onkeyup = null;
+    window.removeEventListener("mousewheel",mouseWheelHandler);
+    window.removeEventListener("DOMMouseScroll",mouseWheelHandler);
+    onmousedown = null;
+}
+
+//Whether a movement key is held; drives the hero's walk animation.
+var hero_moving = false;
+function hero_move_animation_check(){
+        var hero_was = hero_moving;
+        if(keys['w'] || keys['a'] || keys['s'] || keys['d'])hero_moving = true;
+        else hero_moving = false;
+        if(hero_moving && !hero_was){
+            hero.feet_clip.gotoAndPlay(0);
+            hero.sprite_animate = true;
+        }
+        if(!hero_moving){
+            hero.feet_clip.gotoAndStop(0);
+            hero.sprite_animate = false;
+        }
+}

--- a/src/systems/particles.ts
+++ b/src/systems/particles.ts
@@ -1,0 +1,179 @@
+/**
+ * Particle system (roadmap §2.2 strangler step, Phase 2).
+ *
+ * Shell casings, wall shards and blood droplets: spawned by the splatter/eject
+ * functions, advanced once per fixed step by updateParticles(). Moved verbatim out
+ * of main.ts; still reads the shared world state (`shells`, `grid`,
+ * `particle_container`, sprite-sheet handles, ...) as window globals until those
+ * gain owners of their own. Per-tick motion constants are correct here because the
+ * gameloop runs at a fixed 60 Hz.
+ */
+
+//Tuning constants. Only this module reads them (they were window globals in main.ts).
+var shell_speed = 10;
+var blood_speed = 1;
+var shard_limit = 2000;
+//Which shard image the next shard uses; images_from_sheet.ts reads it at load time to
+//pick the initial `currentShard`, so it stays a window global.
+window.shardType = 0;
+
+//Controls the behavior of a particle during one game tick
+function tickParticle(particle,tick_max,bounce){
+    //particle should have .dy .dx .dr. and tick
+    particle.position.y += particle.dy;
+    //check the y to see if it has gone into a wall
+    if(grid.isWallSolid_coords(particle.position.x,particle.position.y)){
+        particle.position.y -= particle.dy*2;
+        particle.dy *= -1;
+    }
+    particle.position.x -= particle.dx;
+        //check the x to see if it has gone into a wall
+        if(grid.isWallSolid_coords(particle.position.x,particle.position.y)){
+            // if particle should bounce off walls
+            if(bounce){
+                    particle.position.x += particle.dx*2;
+                    particle.dx *= -1;
+            }else{
+                return true;
+            }
+        }
+
+    particle.dx *= 0.9;
+    particle.dy *= 0.9;
+    particle.rotation += particle.dr;
+    particle.tick++;
+    //remove from array once it is done moving (OPTIMIZATION)
+    if(particle.tick > tick_max){
+        return true;//remove it from array
+    }
+    return false;
+}
+
+//Advance every live particle one fixed step; called from gameloop().
+export function updateParticles(deltaTime){
+    for(var i = 0; i < shells.length; i++){
+        if(tickParticle(shells[i],20,true)){
+            shells.splice(i,1);
+            i--;
+        }
+    }
+    for(var i = 0; i < shards.length; i++){
+        if(tickParticle(shards[i],20,true)){
+            shards.splice(i,1);
+            i--;
+        }
+    }
+    for(var i = 0; i < bloods.length; i++){
+        var blood = bloods[i];
+        //shrink blood particle:
+        blood.scale.x*=0.7;
+        blood.scale.y*=0.7;
+
+
+        var blood_x_mod = randomFloatWithBias2(-10,10);
+        var blood_y_mod = randomFloatWithBias2(-10,10);
+        var blood_size_mod = randomFloatWithBias2(1,blood.scale.y*20);
+        //var skip_blood_draw = randomIntFromInterval(0,3);
+        drawBloodTrail(blood.position.x+blood_x_mod,blood.position.y+blood_y_mod,blood_size_mod);
+
+        //remove when done ticking
+        if(tickParticle(blood,7,false)){
+            bloods.splice(i,1);
+            i--;
+        }
+
+    }
+}
+
+export function shardParticleSplatter(angle,target){
+    var shardAmount = randomIntFromInterval(6,30);
+        angle += Math.PI/2;//I don't know why it's off by Pi/2 but it is.
+    for(var i = 0; i < shardAmount; i++){
+        var shard = new PIXI.Sprite(currentShard);
+
+
+        shard.anchor.x = 0.5;
+        shard.anchor.y = 0.5;
+        shard.position.x = target.x;
+        shard.position.y = target.y;
+        var randScale = randomFloatFromInterval(0.3,1);
+        shard.scale.x = randScale;
+        shard.scale.y = randScale;
+        var randSpeed = randomFloatWithBias(0.1,shell_speed*2);
+        var randRotationOffset = randomFloatFromInterval(-Math.PI/6,Math.PI/6);
+        shard.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
+        shard.dx = randSpeed*Math.sin(angle+randRotationOffset);
+        shard.dy = randSpeed*Math.cos(angle+randRotationOffset);
+        shard.tick = 0;//the amount of times that it has moved;
+        shard.rotation = (angle);
+
+        shards.push(shard);
+        particle_container.addChild(shard);
+
+        //rotate to next image:
+        window.shardType++;
+        window.shardType %= shardImages.length;
+        window.currentShard = shardImages[shardType];
+
+        if(shards.length > shard_limit)return;
+    }
+
+}
+export function bloodParticleSplatter(angle,target){
+    //var bloodAmount = randomIntFromInterval(15,30);
+    var bloodAmount = randomIntFromInterval(30,60);
+    angle += Math.PI/2;//I don't know why it's off by Pi/2 but it is.
+    var bloodSplat;
+    for(var i = 0; i < bloodAmount; i++){
+        bloodSplat = new PIXI.Sprite();
+
+
+        bloodSplat.anchor.x = 0.5;
+        bloodSplat.anchor.y = 0.5;
+        /*var randScale = randomFloatFromInterval(1,2);
+        bloodSplat.scale.x = randScale;
+        bloodSplat.scale.y = randScale;*/
+        var randSpeed = randomFloatWithBias(0.7,blood_speed);
+        var randRotationOffset = randomFloatWithBias(0,Math.PI/4);
+        var negativeRotationOffset = randomIntFromInterval(0,2);
+        if(negativeRotationOffset)randRotationOffset *= -1;
+        bloodSplat.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
+        bloodSplat.dx = -randSpeed*Math.sin(angle+randRotationOffset)*15;
+        bloodSplat.dy = -randSpeed*Math.cos(angle+randRotationOffset)*15;
+        //start the blood off a little away from target
+        bloodSplat.position.x = target.x+Math.sin(angle)*20;
+        bloodSplat.position.y = target.y+Math.cos(angle)*20;
+        bloodSplat.tick = 0;//the amount of times that it has moved;
+        bloodSplat.rotation = (angle);
+
+        bloods.push(bloodSplat);
+    }
+
+}
+export function ejectShell(source){
+
+    var shell = new PIXI.Sprite(img_shell);
+
+
+    shell.anchor.x = 0.5;
+    shell.anchor.y = 0.5;
+    shell.position.x = source.x;
+    shell.position.y = source.y;
+    shell.scale.x = 0.5;
+    shell.scale.y = 0.5;
+    var randSpeed = randomFloatWithBias(shell_speed*0.6,shell_speed*2);
+    var randRotationOffset = randomFloatFromInterval(-Math.PI/6,Math.PI/6);
+    shell.dr = randomFloatFromInterval(-0.3,0.3);//change in rotation
+    shell.dx = randSpeed*Math.sin(source.sprite.rotation+randRotationOffset);
+    shell.dy = randSpeed*Math.cos(source.sprite.rotation+randRotationOffset);
+    shell.tick = 0;//the amount of times that it has moved;
+    shell.rotation = (source.sprite.rotation);
+
+    shells.push(shell);
+    particle_container.addChild(shell);
+    //cycle shell texture
+	/*shellType++
+	shellType %= 5;
+	currentTexture = shellTextures[shellType];*/
+    //
+}

--- a/test/core/clock.test.ts
+++ b/test/core/clock.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it, vi } from 'vitest';
+import { GameClock } from '../../src/core/clock';
+
+describe('GameClock.now', () => {
+  it('starts at zero and advances only with update()', () => {
+    const clock = new GameClock();
+    expect(clock.now()).toBe(0);
+    clock.update(16);
+    clock.update(16);
+    expect(clock.now()).toBe(32);
+  });
+
+  it('ignores negative dt', () => {
+    const clock = new GameClock();
+    clock.update(100);
+    clock.update(-50);
+    expect(clock.now()).toBe(100);
+  });
+});
+
+describe('GameClock.after', () => {
+  it('fires once when the delay has elapsed, not before', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    clock.after(100, fn);
+    clock.update(99);
+    expect(fn).not.toHaveBeenCalled();
+    clock.update(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    clock.update(1000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('is pause-safe: no update, no firing, and the remaining delay survives the gap', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    clock.after(100, fn);
+    clock.update(60);
+    // ...game paused here: gameloop stops calling update(), wall time passes...
+    expect(fn).not.toHaveBeenCalled();
+    clock.update(39);
+    expect(fn).not.toHaveBeenCalled();
+    clock.update(1); // resumes exactly where it left off
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires non-positive delays on the next update', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    clock.after(0, fn);
+    clock.after(-5, fn);
+    expect(fn).not.toHaveBeenCalled();
+    clock.update(0);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires timers in due order within one update', () => {
+    const clock = new GameClock();
+    const order: string[] = [];
+    clock.after(200, () => order.push('b'));
+    clock.after(100, () => order.push('a'));
+    clock.after(300, () => order.push('c'));
+    clock.update(1000);
+    expect(order).toEqual(['a', 'b', 'c']);
+  });
+
+  it('supports the nested-timeout pattern (a callback scheduling another after)', () => {
+    // sprite_guard's reaction: after(500) -> becomeAlarmed, then after(2000) -> alert all.
+    const clock = new GameClock();
+    const events: string[] = [];
+    clock.after(500, () => {
+      events.push('alarmed');
+      clock.after(2000, () => events.push('alert-others'));
+    });
+    clock.update(500);
+    expect(events).toEqual(['alarmed']);
+    clock.update(1999);
+    expect(events).toEqual(['alarmed']);
+    clock.update(1);
+    expect(events).toEqual(['alarmed', 'alert-others']);
+  });
+
+  it('does not fire a timer scheduled during the update it was scheduled in, even at 0 delay', () => {
+    const clock = new GameClock();
+    let chained = 0;
+    clock.after(0, function reschedule() {
+      chained++;
+      clock.after(0, reschedule);
+    });
+    clock.update(10);
+    expect(chained).toBe(1); // one per update, not an infinite loop inside one tick
+    clock.update(10);
+    expect(chained).toBe(2);
+  });
+});
+
+describe('GameClock.every', () => {
+  it('fires once per interval, catching up if one update spans several', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    clock.every(100, fn);
+    clock.update(99);
+    expect(fn).not.toHaveBeenCalled();
+    clock.update(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+    clock.update(350); // covers 200, 300, 400
+    expect(fn).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not drift: beats stay anchored to the schedule, not the update grid', () => {
+    const clock = new GameClock();
+    const times: number[] = [];
+    clock.every(100, () => times.push(clock.now()));
+    for (let i = 0; i < 25; i++) clock.update(16);
+    // 25 * 16 = 400ms -> 4 beats, even though 16 never divides 100
+    expect(times.length).toBe(4);
+  });
+
+  it('rejects non-positive intervals', () => {
+    const clock = new GameClock();
+    expect(() => clock.every(0, () => {})).toThrow();
+    expect(() => clock.every(-10, () => {})).toThrow();
+  });
+
+  it('stops when cancelled from inside its own callback', () => {
+    const clock = new GameClock();
+    let count = 0;
+    const handle = clock.every(10, () => {
+      count++;
+      if (count === 3) handle.cancel();
+    });
+    clock.update(1000);
+    expect(count).toBe(3);
+    clock.update(1000);
+    expect(count).toBe(3);
+  });
+});
+
+describe('cancel and clear', () => {
+  it('cancel() prevents firing and marks the handle done', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    const handle = clock.after(100, fn);
+    expect(handle.done).toBe(false);
+    handle.cancel();
+    clock.update(1000);
+    expect(fn).not.toHaveBeenCalled();
+    expect(handle.done).toBe(true);
+  });
+
+  it('a callback can cancel a not-yet-fired timer in the same update', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    const later = clock.after(200, fn);
+    clock.after(100, () => later.cancel());
+    clock.update(1000);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('clear() cancels everything, including from inside a callback (restart mid-update)', () => {
+    const clock = new GameClock();
+    const fn = vi.fn();
+    clock.after(100, () => clock.clear()); // clearStage() can run from a clock callback
+    clock.after(200, fn);
+    clock.every(50, fn);
+    clock.update(1000);
+    // the every(50) at t=50 fires before the clear at t=100; nothing after survives
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(clock.pendingCount()).toBe(0);
+  });
+
+  it('handles are one-shot done after firing', () => {
+    const clock = new GameClock();
+    const handle = clock.after(10, () => {});
+    clock.update(10);
+    expect(handle.done).toBe(true);
+    expect(clock.pendingCount()).toBe(0);
+  });
+});

--- a/test/core/events.test.ts
+++ b/test/core/events.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventBus } from '../../src/core/events';
+
+describe('EventBus', () => {
+  it('delivers payloads to every subscriber of the event, in subscription order', () => {
+    const bus = new EventBus();
+    const order: string[] = [];
+    bus.on('sound', (p) => order.push('a:' + p));
+    bus.on('sound', (p) => order.push('b:' + p));
+    bus.on('other', () => order.push('never'));
+    bus.emit('sound', 'gunshot');
+    expect(order).toEqual(['a:gunshot', 'b:gunshot']);
+  });
+
+  it('emit on an event with no subscribers is a no-op', () => {
+    const bus = new EventBus();
+    expect(() => bus.emit('nobody-home', 123)).not.toThrow();
+  });
+
+  it('off() and the unsubscribe function both stop delivery', () => {
+    const bus = new EventBus();
+    const viaOff = vi.fn();
+    const viaReturn = vi.fn();
+    bus.on('e', viaOff);
+    const unsub = bus.on('e', viaReturn);
+    bus.emit('e');
+    bus.off('e', viaOff);
+    unsub();
+    bus.emit('e');
+    expect(viaOff).toHaveBeenCalledTimes(1);
+    expect(viaReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it('a handler unsubscribing itself mid-emit does not skip the next handler', () => {
+    const bus = new EventBus();
+    const second = vi.fn();
+    const unsub = bus.on('e', () => unsub());
+    bus.on('e', second);
+    bus.emit('e');
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('a handler subscribed during emit does not receive that same emit', () => {
+    const bus = new EventBus();
+    const late = vi.fn();
+    bus.on('e', () => bus.on('e', late));
+    bus.emit('e');
+    expect(late).not.toHaveBeenCalled();
+    bus.emit('e');
+    expect(late).toHaveBeenCalledTimes(1);
+  });
+
+  it('same handler on two events only detaches from the one passed to off()', () => {
+    const bus = new EventBus();
+    const fn = vi.fn();
+    bus.on('a', fn);
+    bus.on('b', fn);
+    bus.off('a', fn);
+    bus.emit('a');
+    bus.emit('b');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 2 of the roadmap: a fixed 60 Hz timestep with an accumulator-based game loop, a pausable `GameClock` for all gameplay timers, and extracts input, camera, and particle systems into dedicated modules. This fixes framerate-dependent simulation speed and replaces raw `setTimeout` calls with a clock that respects pause state.

## Key Changes

- **Fixed timestep loop**: `animate()` now accumulates wall time and runs `gameloop()` in fixed `STEP_MS` (1000/60 ms) increments. Per-frame movement constants become per-tick constants, making game speed independent of display refresh rate. Includes `MAX_FRAME_MS` cap (250ms) to prevent spiral-of-death on slow machines or tab backgrounding.

- **GameClock system** (`src/core/clock.ts`): Replaces all raw `setTimeout`/`setInterval` with pausable timers:
  - `after(ms, callback)` — one-shot timer
  - `every(ms, callback)` — repeating timer with drift-free scheduling
  - `clear()` — kills all pending timers on game restart (replaces the old loop over window timeout IDs)
  - Only advances when `update(dt)` is called from the fixed-step gameloop, so pause freezes every pending timer automatically

- **EventBus** (`src/core/events.ts`): Minimal pub/sub for FX and AI stimuli. First use: camera kickback now emits `'camera:kickback'` instead of direct function call.

- **System extraction** (strangler pattern):
  - `src/systems/input.ts`: Keyboard/mouse handlers, gameplay actions (bomb, mask, drag, choke)
  - `src/systems/camera.ts`: Zoom, loose follow, map-edge clamping, shake, shot kickback
  - `src/systems/particles.ts`: Shell casings, wall shards, blood droplets with per-tick motion

- **Guard AI timing**: `sprite_guard.ts` and `jo_security_camera.ts` now use `gameClock.after()` instead of `setTimeout()`, so reaction delays respect pause state.

- **Removed globals**: `shell_speed`, `blood_speed` (now module-local tuning constants); `gameloop_zoom_and_camera()` and `tickParticle()` (now in system modules).

- **Initialization fix**: `lastTimeStamp` and `step_accumulator` reset on game start to prevent stale wall-clock time from the menu visit counting as a catch-up burst.

## Notable Implementation Details

- Timers scheduled during an update do not fire in that same update (prevents infinite loops with zero-delay reschedules).
- `every()` timers are drift-free: beats stay anchored to the schedule, not the update grid, even when updates don't align with interval boundaries.
- Particle motion is now truly per-tick (60 Hz), not per-frame, so shell/shard/blood physics are consistent across refresh rates.
- Systems still read shared world state (`hero`, `keys`, `grid`, etc.) as window globals; ownership migration is Phase 3+.

## Testing

- Unit tests for `GameClock` (one-shots, repeating, pause safety, nested scheduling, cancellation)
- Unit tests for `EventBus` (subscription, unsubscription, mid-emit safety)
- Manual verification: 30 FPS cap shows unchanged movement speed; pause mid-action resumes timers correctly

https://claude.ai/code/session_011FfQDdV6nzc54NjoHzUmWR