### PR TITLE
Fix bullet trajectory and dragged guard door unlock logic

### DIFF
--- a/src/legacy/jo_gun.ts
+++ b/src/legacy/jo_gun.ts
@@ -48,7 +48,19 @@ function jo_gun(name,clip_size, silenced, automatic, bullets_per_shot, spread){
             var randomRot = randomIntFromInterval(-this.spread/2,this.spread/2);
             //console.log('random rot: ' + randomRot);
             var endPoint = rotate_point_about_axis({x:unit.x,y:unit.y},randomRot,{x:unit.aim.end.x,y:unit.aim.end.y});
-            //where this shot would stop if nobody were in the way; gameloop_bullets
+            //A bullet keeps flying until it hits something — it must not stop at the point
+            //under the cursor. `aim.end` reaches only as far as the mouse (or the first wall),
+            //so extend the shot's direction well past the map and let sightStop find the wall
+            //it actually runs into. gameloop_bullets raycasts each step, so anyone standing in
+            //the way is still hit before the bullet ever reaches that far wall.
+            var aimDX = endPoint.x - unit.x;
+            var aimDY = endPoint.y - unit.y;
+            var aimLen = Math.sqrt(aimDX*aimDX + aimDY*aimDY);
+            if(aimLen > 0){
+                var BULLET_REACH = 5000;//comfortably beyond the map's diagonal; the border walls stop the ray
+                endPoint = {x: unit.x + aimDX/aimLen*BULLET_REACH, y: unit.y + aimDY/aimLen*BULLET_REACH};
+            }
+            //where this shot stops if nobody is in the way; gameloop_bullets
             //raycasts each step to find out who actually is
             bullet.target = physics.sightStop(unit.x,unit.y,endPoint.x,endPoint.y);
             bullet.rotate_to_instant(bullet.target.x,bullet.target.y);

--- a/src/legacy/main.ts
+++ b/src/legacy/main.ts
@@ -1154,12 +1154,21 @@ function gameloop_doors(deltaTime){
                 tooltip.objY = door_inst.y - 32;
             }
         }
+        //A dragged guard brings their proximity lock along: while you're hauling a guard,
+        //any door they get near opens for you — even a locked one. The door stays locked
+        //(its `unlocked` flag is untouched); it only opens because the guard's lock is in
+        //range, and it closes again once you drag them away. A dead body still carries the
+        //lock, which is why this checks the drag target directly rather than the physics
+        //sensor — a corpse has no body in the world for the sensor to detect.
+        if(hero_drag_target && get_distance(door_center_x,door_center_y,hero_drag_target.x,hero_drag_target.y) <= hero_drag_target.radius*4){
+            door_inst.openerNear = true;
+        }
         if(door_inst.openerNear){
             door_inst.open();
-        
+
         }else{
             door_inst.close();
-        
+
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes two gameplay mechanics: bullet trajectories now extend properly beyond the map boundaries, and dragged guards now correctly unlock doors within their proximity range.

## Key Changes

- **Bullet trajectory extension** (`src/legacy/jo_gun.ts`):
  - Bullets now extend their trajectory well past the map boundary (5000 units) instead of stopping at the cursor position
  - This ensures bullets travel their full distance and hit targets beyond the initial aim point
  - The raycast system still detects collisions at each step, so enemies in the path are still hit correctly
  - Added detailed comments explaining the bullet physics behavior

- **Dragged guard door unlock** (`src/legacy/main.ts`):
  - Guards being dragged by the player now unlock doors within their proximity range (4× their radius)
  - The check uses the drag target directly rather than the physics sensor, so dead bodies still carry their lock
  - Doors remain locked (the `unlocked` flag is untouched) but open when a guard with proximity access is nearby
  - Doors close again once the guard is dragged away
  - Added comprehensive comments explaining the dragged guard unlock mechanic
  - Fixed minor whitespace inconsistencies in the door open/close logic

## Implementation Details

The bullet reach constant (5000 units) is set to comfortably exceed the map's diagonal, relying on border walls to stop the ray naturally. The dragged guard proximity check uses a 4× radius multiplier to define the unlock range, maintaining consistency with the existing proximity lock system.

https://claude.ai/code/session_01468i2jUjXft2TKaXdA9gf1