### PR TITLE
Make van ramming/running over guards a suspicious act

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,15 +47,21 @@ hero worth raising the alarm over:
 | Planting a bomb | `hero.plantingBomb` | During the ~1.5s bomb-plant channel (F key) |
 | Carrying stolen loot | `hero.carry` | Holding the money |
 | Dragging / choking a body | `hero_drag_target` | Dragging a corpse or choking a guard |
+| Just rammed a wall / ran someone over in the van | `hero.vanSuspiciousUntil` | The van hits a wall hard or mows a guard down (`src/systems/car.ts`); a short deadline set by `markVanSuspicious()` |
 
 The mask is protection **until a guard sees your face unmasked** — once a guard sets
 `knowsHerosFace` (`sprite_guard.ts`), the mask no longer hides you from that guard.
 
-**A vehicle is not on this list.** Sitting in or driving the getaway van
-(`hero.inCar`) is deliberately *not* suspicious by itself. Guards react to the van
-only if the hero is doing one of the things above while in it (e.g. driving off with
-the loot, or masked), or once it is driven fast enough to be heard (see below). This
-is intentional: a van is just a van.
+**Calmly driving a vehicle is not on this list; ramming things in it is.** Sitting in
+or gently driving the getaway van (`hero.inCar`) is deliberately *not* suspicious by
+itself — a van is just a van. But the *violent* things a van does are: ramming a wall
+or running a guard over briefly marks the hero suspicious (`hero.vanSuspiciousUntil`,
+a ~2.5s gameClock deadline set from `src/systems/car.ts`). During that window any guard
+or camera that sees the van alarms through the normal detection path — and, if the
+driver is unmasked, learns their face — exactly as for any other suspicious act.
+Guards also react to the van whenever the hero is *already* doing one of the things
+above while in it (e.g. masked, or driving off with the loot), and a fast van is heard
+even when nothing suspicious is happening (see below).
 
 ### How a guard/camera turns a sighting into an alarm
 

--- a/src/legacy/sprite_hero.ts
+++ b/src/legacy/sprite_hero.ts
@@ -54,14 +54,28 @@ function sprite_hero_wrapper(pixiSprite,speed_walk,speed_sprint){
         this.ability_remote_bomb = false;
         this.ability_body_armor = false;
         
+        //A short-lived flag (a gameClock deadline) that marks the hero suspicious right
+        //after the van does something violent — ramming a wall or running a guard over.
+        //Getting in / calmly driving the van is still NOT suspicious (a van is just a van),
+        //but the *act* of ramming or running someone down is, so any guard or camera that
+        //sees the van during this window alarms — and, if the driver is unmasked, learns
+        //their face — through the exact same detection path as every other suspicious act.
+        //Set via markVanSuspicious() from src/systems/car.ts.
+        this.vanSuspiciousUntil = 0;
+        this.markVanSuspicious = function(durationMs){
+            var until = gameClock.now() + durationMs;
+            if(until > this.vanSuspiciousUntil)this.vanSuspiciousUntil = until;
+        }
+
         //The one predicate every guard and camera checks to decide if the hero is worth
         //raising the alarm over. The hero is suspicious only while doing something a guard
         //would react to: wearing a mask, holding a drawn gun, standing on an off-limits
-        //tile, lockpicking a door, planting a bomb, carrying stolen loot, or dragging a
-        //body. Simply sitting in / driving the van is deliberately NOT on this list — a
+        //tile, lockpicking a door, planting a bomb, carrying stolen loot, dragging a body,
+        //or — for a short window — having just rammed a wall or run someone over in the van.
+        //Simply sitting in / calmly driving the van is deliberately NOT on this list — a
         //van is just a van until the hero does one of these things in or near it.
         this.willCauseAlert = function(){
-            if(this.masked || this.gunOut || this.inOffLimits || this.lockpicking || this.plantingBomb || this.carry !== null || hero_drag_target !== null)return true;
+            if(this.masked || this.gunOut || this.inOffLimits || this.lockpicking || this.plantingBomb || this.carry !== null || hero_drag_target !== null || gameClock.now() < this.vanSuspiciousUntil)return true;
             else return false;
         }
         

--- a/src/systems/car.ts
+++ b/src/systems/car.ts
@@ -95,6 +95,15 @@ const NOISE_INTERVAL_MS = 700;
 /** ...and only while actually moving. */
 const NOISE_MIN_SPEED_PX = 60;
 
+/**
+ * How long the driver stays "suspicious" after the van does something violent — ramming a
+ * wall or running a guard over. During the window `hero.willCauseAlert()` is true, so any
+ * guard or camera that sees the van alarms (and, if the driver is unmasked, learns their
+ * face) through the normal detection path. Long enough that a guard who turns toward the
+ * crash a beat later still catches it; short enough that calmly driving on clears it.
+ */
+const VAN_SUSPICION_MS = 2500;
+
 /** Camera in car mode: zoom out and lead the car by its velocity. */
 const CAR_ZOOM_OUT = 1 / 1.3;
 const CAR_LOOKAHEAD_S = 0.5;
@@ -494,6 +503,11 @@ function resolveCarContacts(st: { vx: number; vy: number; speed: number } | null
       const unit = c.owner as any;
       if (unit.alive && driving >= RUN_OVER_SPEED_PX) runOver(unit, st);
     } else if (c.kind === 'cell' && c.cell >= 0 && c.speed >= BREACH_SPEED_PX) {
+      // A hard hit on a wall is a suspicious act whether or not the wall gives: ramming
+      // concrete that shrugs it off is just as much a scene as smashing through drywall.
+      // Only while a driver is at the wheel — a bystander shoving the parked van isn't
+      // the hero's crime.
+      if (active) hero.markVanSuspicious(VAN_SUSPICION_MS);
       // damageCell filters by material: drywall and brick take car damage, concrete and
       // steel (and the map border) shrug it off. The amount is capped low (see
       // BREACH_DAMAGE_MAX) so one impact damages a solid wall but never destroys it.
@@ -507,6 +521,10 @@ function resolveCarContacts(st: { vx: number; vy: number; speed: number } | null
 function runOver(guard: any, st: { vx: number; vy: number; speed: number } | null): void {
   const dirX = st && st.speed > 0 ? st.vx / st.speed : 0;
   const dirY = st && st.speed > 0 ? st.vy / st.speed : 0;
+  // Mowing a guard down is a suspicious act: any other guard or camera that sees the van
+  // during the window alarms (and, unmasked, learns the driver's face). The fresh corpse
+  // is its own alarm source too, but this makes the deed itself count, not just the body.
+  if (active) hero.markVanSuspicious(VAN_SUSPICION_MS);
   bloodParticleSplatter(Math.atan2(dirY, dirX), guard);
   guard.kill();
   knockbacks.push({


### PR DESCRIPTION
## Summary

Adds a short-lived suspicion flag that marks the hero as suspicious immediately after the van rams a wall or runs over a guard. This makes the violent act itself — not just the aftermath — detectable by guards and cameras.

## Changes

- **`src/legacy/sprite_hero.ts`**: Added `vanSuspiciousUntil` (a gameClock deadline) and `markVanSuspicious()` method to track when the van has just done something violent. Updated `willCauseAlert()` to return true while this deadline is active, treating van violence the same as other suspicious acts (mask, gun, lockpicking, etc.).

- **`src/systems/car.ts`**: 
  - Added `VAN_SUSPICION_MS` constant (~2.5s) to define how long the hero stays suspicious after van violence
  - Call `hero.markVanSuspicious()` in `resolveCarContacts()` when the van hits a wall hard enough (`BREACH_SPEED_PX`)
  - Call `hero.markVanSuspicious()` in `runOver()` when the van mows down a guard
  - Both calls only trigger when `active` (driver at the wheel), so a bystander shoving a parked van doesn't count

- **`CLAUDE.md`**: Updated the suspicion conditions table and explanation to document that ramming/running over in the van is now a suspicious act, clarifying the distinction between calmly driving (not suspicious) and violent van acts (suspicious).

## Implementation Details

The window is long enough (~2.5s) that a guard turning toward the crash a beat later still catches it, but short enough that calmly driving on clears the suspicion. During the window, any guard or camera that sees the van alarms through the normal detection path — and if the driver is unmasked, learns their face — exactly as for any other suspicious act.

https://claude.ai/code/session_018sP2e6xyqn56BojNLV8F6J