### PR TITLE
Redesign menu UI and add rebindable keyboard controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,13 +13,22 @@ Guidance for working in this repo. Start with `README.md` (how to run, layout) a
 
 ## Controls
 
-The keyboard/mouse handlers are the single source of truth — `src/systems/input.ts`
-(`addKeyHandlers`), with the debug-overlay cycles in `src/systems/nav_debug.ts`,
-`src/systems/physics_debug.ts`, and `src/systems/breach_debug.ts`.
+Keyboard keys are rebindable. `src/systems/keybindings.ts` is the single source of truth
+for which physical key triggers which action: `KEY_ACTIONS` lists every rebindable action
+with its default `keyCode`, and the stored overrides live in `localStorage`. The keyboard
+handlers — `src/systems/input.ts` (`addKeyHandlers`) — resolve each pressed key through
+`getBindings()` (never a hard-coded `keyCode`), with the debug-overlay cycles in
+`src/systems/nav_debug.ts`, `src/systems/physics_debug.ts`, and
+`src/systems/breach_debug.ts`. To add or change a control, edit `KEY_ACTIONS` and add the
+matching `code == kb.<id>` check in `input.ts`.
 
-The player-facing list of controls lives in the menu (`menu.html`, the "Controls" screen).
-When you add, remove, or rebind a key in `input.ts` — including the bomb (`F`) and the debug
-overlays (`N` / `B` / `H`) — update that menu list to match so the two never drift apart.
+The player-facing Controls list (in the menu's Settings → Controls screen) is generated
+from `KEY_ACTIONS`, so it can't drift from `input.ts`. Mouse buttons, the wheel zoom and
+Esc are deliberately NOT rebindable (they aren't keyboard keys) and are shown as a fixed
+list. The menu itself — main screen, mission select, settings, stats, credits — is
+`menu.html` + `src/menu/`, a self-contained port of the Some of You May Die main menu
+(view switching via a `menu-{name}` body class, settings persisted through
+`src/menu/storage.ts`'s `OPTIONS` blob).
 
 ## How and why guards get alerted
 

--- a/menu.html
+++ b/menu.html
@@ -1,653 +1,708 @@
 <!DOCTYPE HTML>
 <html>
 <head>
-    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
-    <meta content="utf-8" http-equiv="encoding">
-	<title>STEALTH 'em UP</title>
-	<style>
-        *{
-        font-family: 'Roboto', sans-serif;
-        }
-        body{
-            margin: 0px;
-            background-image: url("icons/grimly.png");
-            background-repeat: no-repeat;
-            background-size: cover;
-            background-color: #d9ddec;
-        }
-        canvas {
-            padding-left: 0;
-            padding-right: 0;
-            margin-left: auto;
-            margin-right: auto;
-            display: block;
-        
-        }
-        #stickyHeader{
-            position:fixed;
-            left:0px;
-            top:0px;
-            width:100%;
-            height:40px;
-            background:#afbcec;
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>STEALTH 'em UP</title>
+  <style>
+    /*
+     * Menu styling for STEALTH 'em UP.
+     *
+     * Structure and interaction are ported from Some of You May Die's main menu: a single
+     * #main-menu container holding sibling `.view view-{name}` blocks, with exactly one
+     * shown at a time via a `menu-{name}` class on <body>. The look is a self-contained
+     * dark + gold theme (SoYMD's border-image button skins depend on art this project
+     * doesn't ship, so the skin is reproduced with plain CSS instead).
+     */
+    * {
+      box-sizing: border-box;
+      font-family: 'Roboto', 'Segoe UI', Arial, sans-serif;
+    }
 
-        
-        }
-        .headerButton {
-            height:inherit;
-            float:left;
-            padding: 0 20px 0 20px;
-        }
-        .button2{
-            cursor:pointer;
-            /*disable drag to select text*/
-            -webkit-touch-callout: none;
-            -webkit-user-select: none;
-            -khtml-user-select: none;
-            -moz-user-select: none;
-            -ms-user-select: none;
-            user-select: none;
+    :root {
+      --bg: #15171d;
+      --panel: #1e212a;
+      --panel-2: #252935;
+      --ink: #e9e7df;
+      --ink-dim: #a7a99f;
+      --gold: #d7ad51;
+      --gold-bright: #ecc766;
+      --gold-deep: #8f7126;
+      --line: #363b47;
+      --blue: #3f7fbf;
+    }
 
-            background: #3498db;
-            background-image: -webkit-linear-gradient(top, #3498db, #2980b9);
-            background-image: -moz-linear-gradient(top, #3498db, #2980b9);
-            background-image: -ms-linear-gradient(top, #3498db, #2980b9);
-            background-image: -o-linear-gradient(top, #3498db, #2980b9);
-            background-image: linear-gradient(to bottom, #3498db, #2980b9);
-            font-family: Arial;
-            color: #ffffff;
-            font-size: 20px;
-            text-decoration: none;
-        
-        }
-        .button2.button2clickable:hover {
-            background: #3cb0fd;
-            text-decoration: none;
-        }
-        .button2.button2clickable:active {
-            background: #3cb0fd;
-            background-image: -webkit-linear-gradient(top, #3498db, #3cb0fd);
-            background-image: -moz-linear-gradient(top, #3498db, #3cb0fd);
-            background-image: -ms-linear-gradient(top, #3498db, #3cb0fd);
-            background-image: -o-linear-gradient(top, #3498db, #3cb0fd);
-            background-image: linear-gradient(to bottom, #3498db, #3cb0fd);
-            text-decoration: none;
-        }
-        .headerButton>span{
-            display: table-cell;
-            height: 40px;
-            vertical-align: middle; 
-        }
-        .body_content{
-            margin-top:40px;
-        }
-        
-        #footer{
-            position:fixed;
-            left:0px;
-            bottom:0px;
-            /*height:104px;*/
-            width:100%;
-            background:#afbcec;
-        }
-        /* Für ie6*/
-        * html #footer{
-            position:absolute;
-            top:expression((0-(footer.offsetHeight)+(document.documentElement.clientHeight ? document.documentElement.clientHeight : document.body.clientHeight)+(ignoreMe = document.documentElement.scrollTop ? document.documentElement.scrollTop : document.body.scrollTop))+'px');
-        }	
-        
-        .btn {
-            border: none;
-            font-family: inherit;
-            font-size: inherit;
-            color: inherit;
-            background: none;
-            cursor: pointer;
-            padding: 25px 32px;
-            /*width: 15%;
-            height: 80%;*/
-            display: inline-block;
-            margin: 15px 8px;
-            text-transform: uppercase;
-            letter-spacing: 1px;
-            font-weight: 700;
-            outline: none;
-            position: relative;
-            -webkit-transition: all 0.3s;
-            -moz-transition: all 0.3s;
-            transition: all 0.3s;
-        }
-        .btn-1 {
-            border: 3px solid #4c5267;
-            color: #4c5267;
-        }
+    html, body {
+      height: 100%;
+    }
 
-        /* Button 1a */
-        .currentMenuItem,
-        .btn-1a:hover,
-        .btn-1a:active {
-            color: #afbcec;
-            background: #4c5267;
-        }
-        
-        .levelSelect{
-            margin-bottom: 0px; 
-        }
-        #datatablesdiv tr { cursor: pointer; cursor: hand; }
-        
-        #mc_embed_signup{background:#fff; font:14px Helvetica,Arial,sans-serif;  width:390px;}
-        
-	</style>
-    <link href='http://fonts.googleapis.com/css?family=Roboto' rel='stylesheet' type='text/css'>
-    
-    <script src="https://code.jquery.com/jquery-2.1.1.min.js"></script>
-    
-    <link href="//cdn.datatables.net/1.10.4/css/jquery.dataTables.min.css" rel="stylesheet" type="text/css">
-    <script src="//cdn.datatables.net/1.10.4/js/jquery.dataTables.min.js"></script>
-    
-    <script src="/bin/pixi.js"></script>
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: #0f1116;
+      overflow: hidden;
+      -webkit-user-select: none;
+      user-select: none;
+    }
 
-    <!-- The achievements panel reads the jo_store_* helpers; loading them as a module
-         keeps this page on the same source as the game (see src/menu.ts). -->
-    <script type="module" src="/src/menu.ts"></script>
+    #main-menu {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background:
+        linear-gradient(rgba(15, 17, 22, 0.86), rgba(15, 17, 22, 0.94)),
+        url("icons/grimly.png") center / cover no-repeat;
+      background-color: var(--bg);
+    }
+
+    /* --- View switching -------------------------------------------------- */
+    #main-menu .view {
+      display: none;
+      width: min(1040px, 94vw);
+      max-height: 92vh;
+    }
+
+    body.menu-main #main-menu .view-main,
+    body.menu-play #main-menu .view-play,
+    body.menu-settings #main-menu .view-settings,
+    body.menu-achievements #main-menu .view-achievements,
+    body.menu-credits #main-menu .view-credits {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    /* --- Buttons (dark/gold skin) --------------------------------------- */
+    #main-menu .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      cursor: pointer;
+      padding: 12px 22px;
+      min-width: 160px;
+      color: var(--ink);
+      background: linear-gradient(180deg, var(--panel-2), var(--panel));
+      border: 2px solid var(--line);
+      border-radius: 6px;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      text-align: center;
+      transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.05s;
+    }
+
+    #main-menu .btn:hover {
+      border-color: var(--gold);
+      color: var(--gold-bright);
+      background: linear-gradient(180deg, #2c3140, #232733);
+    }
+
+    #main-menu .btn:active {
+      transform: translateY(1px);
+    }
+
+    #main-menu .btn.active {
+      border-color: var(--gold);
+      color: #1a1206;
+      background: linear-gradient(180deg, var(--gold-bright), var(--gold));
+    }
+
+    #main-menu .btn.btn-blue {
+      border-color: #2f5f90;
+      color: #f2f7ff;
+      background: linear-gradient(180deg, #3f7fbf, #2f5f90);
+    }
+
+    #main-menu .btn.btn-blue:hover {
+      border-color: var(--gold-bright);
+      background: linear-gradient(180deg, #4a8fd0, #356aa0);
+      color: #fff;
+    }
+
+    /* --- Main view ------------------------------------------------------- */
+    .view-main #main-menu-inner {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 34px;
+    }
+
+    .game-logo {
+      margin: 0;
+      font-size: clamp(46px, 9vw, 92px);
+      font-weight: 900;
+      letter-spacing: 4px;
+      line-height: 0.92;
+      color: var(--ink);
+      text-shadow: 0 4px 0 #000, 0 0 26px rgba(215, 173, 81, 0.28);
+      text-align: center;
+    }
+
+    .game-logo span {
+      color: var(--gold);
+      display: inline-block;
+      margin: 0 8px;
+      font-size: 0.5em;
+      vertical-align: middle;
+      transform: rotate(-6deg);
+    }
+
+    .tagline {
+      margin-top: 10px;
+      text-align: center;
+      color: var(--ink-dim);
+      letter-spacing: 6px;
+      text-transform: uppercase;
+      font-size: 15px;
+    }
+
+    .menu-buttons {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      width: 300px;
+    }
+
+    .menu-buttons .btn {
+      width: 100%;
+    }
+
+    /* --- Shared view header --------------------------------------------- */
+    .view-header {
+      display: flex;
+      align-items: center;
+      gap: 18px;
+      width: 100%;
+      padding: 6px 4px 16px;
+      border-bottom: 1px solid var(--line);
+      margin-bottom: 18px;
+    }
+
+    .view-header h2 {
+      margin: 0;
+      font-size: 26px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: var(--gold);
+    }
+
+    .view-header .btn {
+      min-width: 0;
+      padding: 8px 16px;
+      font-size: 15px;
+    }
+
+    /* --- Scroll areas ---------------------------------------------------- */
+    .scrollable {
+      overflow-y: auto;
+      width: 100%;
+    }
+
+    .scrollable::-webkit-scrollbar {
+      width: 0.5em;
+    }
+
+    .scrollable::-webkit-scrollbar-thumb {
+      background-color: var(--gold-deep);
+      border-radius: 3px;
+      outline: 1px solid #313131;
+    }
+
+    /* --- Play / Mission select ------------------------------------------ */
+    .view-play {
+      background: rgba(20, 22, 28, 0.72);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 24px 28px;
+    }
+
+    .mission-list {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      max-height: 64vh;
+    }
+
+    #main-menu .mission-card.btn {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 6px;
+      text-transform: none;
+      text-align: left;
+      padding: 18px 22px;
+      width: 100%;
+    }
+
+    .mission-name {
+      font-size: 20px;
+      font-weight: 700;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: var(--gold-bright);
+    }
+
+    #main-menu .mission-card.btn:hover .mission-name {
+      color: var(--gold-bright);
+    }
+
+    .mission-desc {
+      font-size: 14px;
+      font-weight: 400;
+      color: var(--ink-dim);
+      letter-spacing: 0.3px;
+    }
+
+    /* --- Settings -------------------------------------------------------- */
+    .view-settings {
+      background: rgba(20, 22, 28, 0.78);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      overflow: hidden;
+      height: 82vh;
+    }
+
+    #settings-container {
+      display: flex;
+      flex-direction: row;
+      width: 100%;
+      height: 100%;
+    }
+
+    #settings-sidebar {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      width: 210px;
+      flex: 0 0 210px;
+      padding: 20px 16px;
+      border-right: 1px solid var(--line);
+      background: rgba(0, 0, 0, 0.18);
+    }
+
+    #settings-sidebar .btn {
+      width: 100%;
+    }
+
+    .settings-nav-btn {
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      padding: 11px 16px;
+      border: 2px solid transparent;
+      border-radius: 6px;
+      font-size: 16px;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+      transition: background 0.15s, color 0.15s;
+    }
+
+    .settings-nav-btn:hover {
+      color: var(--ink);
+      background: rgba(215, 173, 81, 0.12);
+    }
+
+    .settings-nav-btn.active {
+      color: #1a1206;
+      background: linear-gradient(180deg, var(--gold-bright), var(--gold));
+    }
+
+    #settings-content {
+      flex: 1 1 auto;
+      padding: 24px 30px;
+    }
+
+    .settings-section {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      align-items: flex-start;
+    }
+
+    .settings-section h2 {
+      margin: 0;
+      font-size: 22px;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      color: var(--gold);
+    }
+
+    .settings-help {
+      margin: 0;
+      color: var(--ink-dim);
+      font-size: 14px;
+    }
+
+    .settings-field {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      width: 100%;
+      max-width: 420px;
+    }
+
+    .settings-field label {
+      color: var(--ink-dim);
+      font-size: 14px;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+    }
+
+    input[type="range"] {
+      width: 100%;
+      accent-color: var(--gold);
+      cursor: pointer;
+    }
+
+    /* --- Keybindings ----------------------------------------------------- */
+    #keybindings-list {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+      width: 100%;
+    }
+
+    .keybind-group h3 {
+      margin: 0 0 8px;
+      font-size: 14px;
+      letter-spacing: 2px;
+      text-transform: uppercase;
+      color: var(--ink-dim);
+      border-bottom: 1px solid var(--line);
+      padding-bottom: 6px;
+    }
+
+    .keybind-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 6px 0;
+    }
+
+    .keybind-label {
+      font-size: 15px;
+      color: var(--ink);
+    }
+
+    #main-menu .btn.btn-key {
+      min-width: 118px;
+      padding: 8px 14px;
+      font-size: 15px;
+      text-transform: none;
+      font-family: 'Courier New', monospace;
+      font-weight: 700;
+      letter-spacing: 1px;
+    }
+
+    .keybind-fixed {
+      min-width: 118px;
+      padding: 8px 14px;
+      font-size: 15px;
+      font-family: 'Courier New', monospace;
+      font-weight: 700;
+      letter-spacing: 1px;
+      color: var(--ink-dim);
+      text-align: center;
+    }
+
+    .fixed-controls {
+      opacity: 0.85;
+    }
+
+    #main-menu .btn.btn-key.listening {
+      border-color: var(--gold-bright);
+      color: var(--gold-bright);
+      background: rgba(215, 173, 81, 0.14);
+      animation: pulse 1s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.55; }
+    }
+
+    /* --- Stats & achievements ------------------------------------------- */
+    .view-achievements {
+      background: rgba(20, 22, 28, 0.78);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 24px 28px;
+      height: 82vh;
+    }
+
+    .stats-wrap {
+      display: flex;
+      flex-direction: column;
+      gap: 26px;
+      max-height: 70vh;
+    }
+
+    .stats-panel {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      max-width: 460px;
+    }
+
+    .stat-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .stat-label {
+      color: var(--ink-dim);
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-size: 14px;
+    }
+
+    .stat-value {
+      color: var(--gold-bright);
+      font-weight: 700;
+    }
+
+    .achievements-panel {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+      gap: 14px;
+    }
+
+    .achievement-card {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 12px 14px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+    }
+
+    .achievement-card img {
+      width: 46px;
+      height: 46px;
+      object-fit: contain;
+      flex: 0 0 auto;
+    }
+
+    .achievement-card .ach-name {
+      font-weight: 700;
+      color: var(--gold);
+      letter-spacing: 0.5px;
+    }
+
+    .achievement-card .ach-desc {
+      font-size: 13px;
+      color: var(--ink-dim);
+    }
+
+    /* --- Credits --------------------------------------------------------- */
+    .view-credits {
+      background: rgba(20, 22, 28, 0.78);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 24px 28px;
+      height: 70vh;
+    }
+
+    .credits {
+      max-height: 54vh;
+      line-height: 1.7;
+      color: var(--ink);
+    }
+
+    .credits h3 {
+      color: var(--gold);
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin: 18px 0 6px;
+    }
+
+    .credits a {
+      color: var(--gold-bright);
+    }
+
+    /* --- Toast ----------------------------------------------------------- */
+    #menu-toast {
+      position: fixed;
+      left: 50%;
+      bottom: 32px;
+      transform: translateX(-50%) translateY(20px);
+      background: var(--panel-2);
+      color: var(--ink);
+      border: 1px solid var(--gold);
+      border-radius: 6px;
+      padding: 12px 20px;
+      font-size: 15px;
+      max-width: 80vw;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s, transform 0.2s;
+      z-index: 50;
+    }
+
+    #menu-toast.show {
+      opacity: 1;
+      transform: translateX(-50%) translateY(0);
+    }
+  </style>
 </head>
-    <script>
-        function finishedloading(text){
-            console.log('Finished loading: ' + text);
-        }
-        
-        function getUrlVars()
-        {
-            var vars = [], hash;
-            var hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-            for(var i = 0; i < hashes.length; i++)
-            {
-                hash = hashes[i].split('=');
-                vars.push(hash[0]);
-                vars[hash[0]] = hash[1];
-            }
-            return vars;
-        }
-    </script>
-    <body onload="finishedloading('body');">
-    <div id="stickyHeader">
-        <div class="headerButton button2">
-            <span>Missions Remaining:</span>
+
+<body class="menu-main">
+  <div id="main-menu">
+
+    <!-- Main menu ------------------------------------------------------- -->
+    <div class="view view-main">
+      <div id="main-menu-inner">
+        <div class="logo-block">
+          <h1 class="game-logo">STEALTH<span>'em</span>UP</h1>
+          <div class="tagline">Rob 'em Blind</div>
         </div>
-        <div class="headerButton button2 button2clickable" onclick="showMenuScreen('levelSelect');">
-            <span>Mission Select</span>
-            
+        <div class="menu-buttons">
+          <div class="btn btn-blue" data-view="play">Play</div>
+          <div class="btn" data-view="settings">Settings</div>
+          <div class="btn" data-view="achievements">Stats</div>
+          <div class="btn" data-view="credits">Credits</div>
         </div>
-        <div class="headerButton button2 button2clickable" onclick="showMenuScreen('startScreen');">
-            <span>Controls</span>
-            
-        </div>
+      </div>
     </div>
-    
-    <div id="canvas_holder"></div>
-    <!-- This page used to <script>-load the whole game here purely to warm the browser
-         cache before game.html asked for the same files. The game is a single bundled
-         module entry now, so there is nothing left to preload. -->
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-56798370-1', 'auto');
-      ga('send', 'pageview');
-
-    </script>
-            
-    <div id="startScreen" class="body_content" align="right">
-        <!--<div><button type="button" class="btn btn-1 btn-1a" onclick="location.href='/game.html?volume=0.0'">Start Game (Muted)</button></div>-->
-
-        
-        <table>
-        <tr>
-            <td>
-            <b>Controls:</b>
-            </td>
-            <td>
-            </td>
-        </tr>
-        <tr></tr>
-        <tr>
-            <td>
-            Movement:
-            </td>
-            <td>
-            W A S D
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Put On Mask:
-            </td>
-            <td>
-            V
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Draw Weapon:
-            </td>
-            <td>
-            G
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Place / Detonate Explosive
-            </td>
-            <td>
-            F
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Reload:
-            </td>
-            <td>
-            R
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Switch Weapon
-            </td>
-            <td>
-            1-6
-            </td>
-        </tr>
-        <tr>
-            
-            <td>
-            Shoot (While Weapon is Drawn):  
-            </td>
-            <td>
-            Left Click
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Lock-pick Door:
-            </td>
-            <td>
-            Hold Space
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Interact:
-            </td>
-            <td>
-            Space
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Drag Body:
-            </td>
-            <td>
-            Hold Space
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Zoom:
-            </td>
-            <td>
-            Mouse Wheel
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Choke Out Guard:
-            </td>
-            <td>
-            Space
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Sprint:
-            </td>
-            <td>
-            Hold Shift
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Spyglass / Binoculars:
-            </td>
-            <td>
-            P
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Pick Up Gun:
-            </td>
-            <td>
-            Right Click
-            </td>
-        </tr>
-
-        </table>
-        <br><br><br>
-        <table>
-        <tr>
-            <td>
-            <b>Bomb (F):</b>
-            </td>
-            <td>
-            </td>
-        </tr>
-        <tr></tr>
-        <tr>
-            <td>
-            Timed bomb: plant with F, detonates on a 5s fuse.
-            </td>
-            <td>
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Remote bomb: press F to plant, press F again to detonate.
-            </td>
-            <td>
-            </td>
-        </tr>
-        </table>
-        <br><br><br>
-        <table>
-        <tr>
-            <td>
-            <b>Debug Overlays:</b>
-            </td>
-            <td>
-            </td>
-        </tr>
-        <tr></tr>
-        <tr>
-            <td>
-            Nav / Pathfinding (off / paths / regions / danger / flow):
-            </td>
-            <td>
-            N
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Physics / Fog (off / fixtures / occluders / polygon):
-            </td>
-            <td>
-            B
-            </td>
-        </tr>
-        <tr>
-            <td>
-            Wall Destruction (off / materials / hp):
-            </td>
-            <td>
-            H
-            </td>
-        </tr>
-        </table>
-        <br><br><br>
-        <table>
-        <tr>
-            <td>
-            -Grey Tiles are restricted guards will <br> automatically attack you if they see you <br> standing on a grey tile.
-            </td>
-        </tr>
-        <tr>
-        </tr>
-        <tr>
-        </tr>
-        <tr>
-            <td>
-            -Brown Tiles are tables.  Enemies can <br>shoot and see past them, but cannot <br>move past them.
-            </td>
-        </tr>
-        <tr>
-        </tr>
-        <tr>
-        </tr>
-        <tr>
-            <td>
-            -Black Tiles are walls.
-            </td>
-        </tr>
-        </table>
-
-        <!---<div><video autoplay loop muted width="400" height="300">
-            <source src="test.webm" type='video/webm; codecs="vp8, vorbis"'>
-        </video></div>-->
-        
-        </table>
-        <br><br><br>
-        
-
- 
-
+    <!-- Mission select -------------------------------------------------- -->
+    <div class="view view-play">
+      <div class="view-header">
+        <div class="btn" data-view="main">&#x2190; Back</div>
+        <h2>Mission Select</h2>
+      </div>
+      <div id="mission-list" class="mission-list scrollable"></div>
     </div>
-    <!--
-    <div class="btn btn-1 btn-1a" style="display: block; width: 300px; height: 120px;" onclick="location.href='./game.html?volume=1.0&level=diamondStore'">
-            <h1 class="levelSelect" align="center">Diamond Store</h1>
-        </div>
-        <div class="btn btn-1 btn-1a" style="display: block; width: 300px; height: 120px;" onclick="location.href='./game.html?volume=1.0&level=bank1'">
-            <h1 class="levelSelect" align="center">International Bank</h1>
-        </div>
-    -->
-    <div id="levelSelect" class="body_content" align="right">
-        <div id="datatablesdiv" style="max-width:70%;margin:50px;background-color: rgba(255,255,255,0.9);">
-        </div>
-        
-    </div>
-    <div id="achievements" class="body_content" align="right">
-        
-        <table>
-        <tr>
-            <td>
-                <div id="playerStats"></div>
-            </td>
-            <td>
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <p><b>Ghost</b> <br> Never Seen</p>
-            </td>
-            <td>
-            <img src="icons/ghost.png">
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <p><b>Pacifist</b> <br> None Dead</p>
-            </td>
-            <td>
-            <img src="icons/peace.png">
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <p><b>Flawless</b> <br> Never Seen, None Dead</p>
-            </td>
-            <td>
-            <img src="icons/flawless.png">
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <p><b>Speedy</b> <br> Completed Quickly</p>
-            </td>
-            <td>
-            <img src="icons/speedy.png">
-            </td>
-        </tr>
-        <tr>
-            <td>
-                <p><b>Never Give Up</b> <br> Completed After Police <br> Backup Arrives</p>
-            </td>
-            <td>
-                <img src="icons/ngu.png">
-            </td>
-        </tr>
-        </table>
-    </div>
-    <div align="right" id="mailingList" class="body_content" >
-        <!-- Begin MailChimp Signup Form -->
-        <link href="//cdn-images.mailchimp.com/embedcode/classic-081711.css" rel="stylesheet" type="text/css">
 
-        <div id="mc_embed_signup">
-        <form action="//triagegame.us9.list-manage.com/subscribe/post?u=f089bff381b5dde5efe54f853&amp;id=8917d648ec" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-            <div id="mc_embed_signup_scroll">
-            <h2>Mailing List - Only used for major news</h2>
-        <div class="mc-field-group">
-            <label for="mce-EMAIL">Email Address </label>
-            <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+    <!-- Settings -------------------------------------------------------- -->
+    <div class="view view-settings">
+      <div id="settings-container">
+        <div id="settings-sidebar">
+          <div class="btn" data-view="main">&#x2190; Back</div>
+          <div class="settings-nav-btn active" data-fn="menu-act" data-act="settings-category"
+            data-value="controls">Controls</div>
+          <div class="settings-nav-btn" data-fn="menu-act" data-act="settings-category" data-value="audio">Audio</div>
+          <div class="settings-nav-btn" data-fn="menu-act" data-act="settings-category" data-value="other">Other</div>
         </div>
-            <div id="mce-responses" class="clear">
-                <div class="response" id="mce-error-response" style="display:none"></div>
-                <div class="response" id="mce-success-response" style="display:none"></div>
-            </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-            <div style="position: absolute; left: -5000px;"><input type="text" name="b_f089bff381b5dde5efe54f853_8917d648ec" tabindex="-1" value=""></div>
-            <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+        <div id="settings-content" class="scrollable">
+
+          <!-- Controls / keybindings -->
+          <div class="settings-section" data-settings-category="controls">
+            <h2>Controls</h2>
+            <p class="settings-help">Click a key, then press the new key to rebind it. Press Esc to cancel. Bindings are
+              saved automatically and used the next time you play.</p>
+            <div id="keybindings-list"></div>
+            <div class="btn" data-fn="menu-act" data-act="reset-keybinds">Reset Controls</div>
+            <div class="keybind-group fixed-controls">
+              <h3>Mouse &amp; Fixed</h3>
+              <div class="keybind-row"><span class="keybind-label">Shoot (while weapon drawn)</span><span
+                  class="keybind-fixed">Left Click</span></div>
+              <div class="keybind-row"><span class="keybind-label">Pick Up Gun</span><span class="keybind-fixed">Right
+                  Click</span></div>
+              <div class="keybind-row"><span class="keybind-label">Zoom</span><span class="keybind-fixed">Mouse
+                  Wheel</span></div>
+              <div class="keybind-row"><span class="keybind-label">Menu</span><span
+                  class="keybind-fixed">Esc</span></div>
             </div>
-        </form>
+          </div>
+
+          <!-- Audio -->
+          <div class="settings-section" data-settings-category="audio" style="display:none">
+            <h2>Volume</h2>
+            <div class="settings-field">
+              <label for="volume-total">Master Volume</label>
+              <input id="volume-total" type="range" min="0" max="100" />
+            </div>
+          </div>
+
+          <!-- Other -->
+          <div class="settings-section" data-settings-category="other" style="display:none">
+            <h2>Other</h2>
+            <p class="settings-help">Reset everything — options and rebound controls — back to their defaults.</p>
+            <div class="btn" data-fn="menu-act" data-act="reset-all-settings">Reset All Settings</div>
+          </div>
+
         </div>
-
-        <!--End mc_embed_signup-->
-       
+      </div>
     </div>
-    <div id="feedback" class="body_content" align="right">
-        <iframe src="https://docs.google.com/forms/d/1g9iHmcgLgr4Ob_XtQXY8P5cIKpV4QaSOcXAFXrAADvs/viewform?embedded=true" width="760" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
-    </div>
-    <script>
 
-        var test;
-        //pull level maps from server
-        //fill level select with names of all maps:
-        //get info from php:
-        function getListOfMapNames(){
-            var fileNames;
-            var mapData = [];
-            var oReq = new XMLHttpRequest(); //New request object
-            oReq.onload = function() {
-                //This is where you handle what to do with the response.
-                //The actual data is found on this.responseText
-                console.log(this.responseText); 
-                console.log("NOTE: " + "\"Uncaught SyntaxError: Unexpected token <\" will result if I run this on server without php");
-                fileNames = JSON.parse(this.responseText);
-                dataSet = [];
-                for(var i = 0; i < fileNames.length; i++){
-                    fileNames[i] = fileNames[i].slice(0,-6);
-                    dataSet[i] = [fileNames[i],'...','...','...','...'];
-                    console.log("get file: " + fileNames[i]);
-                }
-                
-                //Make and fill datatable
-                $('#datatablesdiv').html( '<table cellpadding="0" cellspacing="0" border="0" class="display" id="example"></table>' );
-             
-                $('#example').dataTable( {
-                    "data": dataSet,
-                    "columns": [
-                        { "title": "Level Name" },
-                        { "title": "Rating" },
-                        { "title": "Achievements" },
-                        { "title": "Other", "class": "center" },
-                        { "title": "Other", "class": "center" }
-                    ]
-                } ); 
-                
-                //set each datatable row to link to the map
-                $("#datatablesdiv tr").click(function(){
-                    location.href = './game.html?volume=1.0&level=' + $(this).find(".sorting_1")[0].innerHTML;
-                });
-            };
-            oReq.open("get", "maps/get-data.php", true);
-            //                               ^ Don't block the rest of the execution.
-            //                                 Don't wait until the request finishes to 
-            //                                 continue.
-            oReq.send();
-        }
-        getListOfMapNames();
-        function updateStats(){
-            var wins = jo_store_get("wins");
-            var loses = jo_store_get("loses");
-            var guardsShot = jo_store_get("guardsShot");
-            var guardsChoked = jo_store_get("guardsChoked");
-            $("#playerStats").empty();
-            $("#playerStats").append("<b>Statistics<b>");
-            $("#playerStats").append("<br>Wins: " + wins);
-            $("#playerStats").append("<br>Loses: " + loses);
-            $("#playerStats").append("<br>Guards Shot: " + guardsShot);
-            $("#playerStats").append("<br>Guards Choked: " + guardsChoked);
-        }
-        function showMenuScreen(id){
-            //window.history.pushState("object or string", "Title", "./?m=" + id);
-        
-            $("#startScreen").hide();
-            $("#levelSelect").hide();
-            $("#achievements").hide();
-            $("#mailingList").hide();
-            $("#feedback").hide();
-            
-            $("#"+id).show();
-            history.pushState({}, id, "#id");
-            
-            //set no buttons to currentMenuItem
-            $("#button_startScreen").removeClass("currentMenuItem");
-            $("#button_levelSelect").removeClass("currentMenuItem");
-            $("#button_achievements").removeClass("currentMenuItem");
-            $("#button_mailingList").removeClass("currentMenuItem");
-            $("#button_feedback").removeClass("currentMenuItem");
-            //Set the currentMenuItem
-            $("#button_"+id).addClass("currentMenuItem");
-        
-        }
-        
-        //a refresh or regular navigation to the page will show the correct div.
-        if(location.hash.substring(0,1)=='#')showMenuScreen(location.hash.substring(1));
-        else showMenuScreen("startScreen");
-        //no longer used now that is use location.hash
-        /*var url_queryString = getUrlVars();
-        if(url_queryString["m"]){
-            var menuItem = url_queryString["m"];
-            console.log('menu: ' + menuItem.substr(menuItem.length -1));
-            if(menuItem.substr(menuItem.length -1) == "/")menuItem = menuItem.slice(0,-1);
-            showMenuScreen(menuItem);
-        }else{
-            //start out only showing startscreen
-            showMenuScreen("startScreen");
-        }*/
-        //todo test:
-        var dataSet = [
-        ['BANK_1','...','...','...','...'],
-        ['DIAMOND_STORE','...','...','...','...'],
-        ['aPrefilled without php','...','...','...','...'],
-        ['Level4','...','...','...','...'],
-        ['Level5','...','...','...','...'],
-        ['Level6','...','...','...','...'],
-        ['Level7','...','...','...','...'],
-        ['Level8','...','...','...','...'],
-        ['Level9','...','...','...','...'],
-    ];
-     
-    </script>
-    <script> 
-    //browser update check
-    var $buoop = {c:2}; 
-    function $buo_f(){ 
-     var e = document.createElement("script"); 
-     e.src = "//browser-update.org/update.js"; 
-     document.body.appendChild(e);
-    };
-    try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
-    catch(e){window.attachEvent("onload", $buo_f)}
-    </script> 
-	</body>
+    <!-- Stats & achievements -------------------------------------------- -->
+    <div class="view view-achievements">
+      <div class="view-header">
+        <div class="btn" data-view="main">&#x2190; Back</div>
+        <h2>Stats &amp; Achievements</h2>
+      </div>
+      <div class="stats-wrap scrollable">
+        <div id="player-stats" class="stats-panel"></div>
+        <div class="achievements-panel">
+          <div class="achievement-card">
+            <img src="icons/ghost.png" alt="">
+            <div>
+              <div class="ach-name">Ghost</div>
+              <div class="ach-desc">Complete a mission without ever being seen.</div>
+            </div>
+          </div>
+          <div class="achievement-card">
+            <img src="icons/peace.png" alt="">
+            <div>
+              <div class="ach-name">Pacifist</div>
+              <div class="ach-desc">Complete a mission without killing anyone.</div>
+            </div>
+          </div>
+          <div class="achievement-card">
+            <img src="icons/flawless.png" alt="">
+            <div>
+              <div class="ach-name">Flawless</div>
+              <div class="ach-desc">Never seen, none dead.</div>
+            </div>
+          </div>
+          <div class="achievement-card">
+            <img src="icons/speedy.png" alt="">
+            <div>
+              <div class="ach-name">Speedy</div>
+              <div class="ach-desc">Complete a mission quickly.</div>
+            </div>
+          </div>
+          <div class="achievement-card">
+            <img src="icons/ngu.png" alt="">
+            <div>
+              <div class="ach-name">Never Give Up</div>
+              <div class="ach-desc">Complete a mission after police backup arrives.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Credits --------------------------------------------------------- -->
+    <div class="view view-credits">
+      <div class="view-header">
+        <div class="btn" data-view="main">&#x2190; Back</div>
+        <h2>Credits</h2>
+      </div>
+      <div class="credits scrollable">
+        <h3>Stealth 'em Up</h3>
+        <p>A top-down stealth heist game. Mask up, pick the locks, crack the vault, and get
+          out before the guards raise the alarm.</p>
+        <h3>Development</h3>
+        <p>Created by Jordan O'Leary.</p>
+        <h3>Menu</h3>
+        <p>Main-menu shell and settings framework adapted from <em>Some of You May Die</em>.</p>
+      </div>
+    </div>
+
+  </div>
+
+  <script type="module" src="/src/menu.ts"></script>
+</body>
 </html>

--- a/src/menu.ts
+++ b/src/menu.ts
@@ -1,10 +1,16 @@
 /**
  * Menu entry point (`menu.html`).
  *
- * The hub page used to preload every game script so the browser had them cached before
- * `game.html` asked for them. That is pointless now the game is a bundle, so only the
- * one module the page actually calls into — the localStorage helpers behind the upgrade
- * shop — is loaded here. It publishes `jo_store*` onto `window` for the page's inline
- * scripts and `onclick=` handlers.
+ * `jo_local_storage` is imported for its side effect: it republishes the `jo_store*`
+ * localStorage helpers onto `window`, which the Stats screen reads (wins/loses/guards).
+ * `initMenu` wires up the whole menu — the SoYMD-style view switching, settings, and the
+ * rebindable Controls screen — once the DOM is ready.
  */
 import './legacy/jo_local_storage';
+import { initMenu } from './menu/menu';
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMenu);
+} else {
+  initMenu();
+}

--- a/src/menu/menu.ts
+++ b/src/menu/menu.ts
@@ -1,0 +1,295 @@
+/**
+ * Menu behaviour for `menu.html`.
+ *
+ * Modelled on Some of You May Die's `src/menu.ts`: one delegated click listener on
+ * `document.body` drives everything via data attributes.
+ *
+ *   - `data-view="name"`   -> `setMenuView('name')` toggles the `menu-{name}` body class
+ *                             that CSS uses to show exactly one `.view`.
+ *   - `data-fn="menu-act"` + `data-act` + `data-value` -> a switch of menu actions.
+ *   - `data-bind` + `.btn.active` -> option buttons reflect their persisted value
+ *                             (handled by `runBindings` in ./storage).
+ *
+ * SoYMD-only screens (compendium, multiplayer, squads, runes, biomes, ...) are omitted.
+ * What remains is the generic shell — Play, Settings (Audio + Controls + Other), Stats,
+ * Credits — plus a rebindable Controls section, which is the piece SoYMD never shipped a
+ * UI for.
+ */
+import {
+  STORAGE_OPTIONS,
+  assign,
+  getSavedData,
+  remove,
+  runBindings,
+} from './storage';
+import type { MenuOptions } from './storage';
+import {
+  KEY_ACTIONS,
+  codeFor,
+  keyLabel,
+  resetBindings,
+  setBinding,
+} from '../systems/keybindings';
+
+// The playable missions. Mission Select links straight into game.html for the chosen
+// level, carrying the persisted volume. Only bank_1 ships as a real .jomap today; add
+// rows here as more maps land.
+interface Mission {
+  level: string;
+  name: string;
+  desc: string;
+}
+const MISSIONS: Mission[] = [
+  {
+    level: 'bank_1',
+    name: 'International Bank',
+    desc: 'Crack the vault, grab the cash, and vanish before the alarm goes up.',
+  },
+];
+
+let currentOptions: MenuOptions;
+let currentSettingsCategory = 'controls';
+
+/** Switch which `.view` is shown by swapping the `menu-*` class on <body>. */
+function setMenuView(name: string): void {
+  const body = document.body;
+  for (const cls of Array.from(body.classList)) {
+    if (cls.startsWith('menu-')) body.classList.remove(cls);
+  }
+  body.classList.add(`menu-${name}`);
+}
+
+/** Show one settings section and highlight its sidebar tab. */
+function selectSettingsCategory(category: string): void {
+  currentSettingsCategory = category;
+  for (const el of Array.from(document.querySelectorAll<HTMLElement>('.settings-nav-btn'))) {
+    el.classList.toggle('active', el.dataset.value === category);
+  }
+  for (const section of Array.from(
+    document.querySelectorAll<HTMLElement>('.settings-section'),
+  )) {
+    section.style.display = section.dataset.settingsCategory === category ? '' : 'none';
+  }
+}
+
+/** Read a legacy stat counter (persisted by the game via jo_store_inc), defaulting to 0. */
+function stat(name: string): number {
+  const raw = (globalThis as any).jo_store_get?.(name);
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function renderStats(): void {
+  const el = document.getElementById('player-stats');
+  if (!el) return;
+  const rows: Array<[string, number]> = [
+    ['Missions Won', stat('wins')],
+    ['Missions Failed', stat('loses')],
+    ['Guards Shot', stat('guardsShot')],
+    ['Guards Choked Out', stat('guardsChoked')],
+  ];
+  el.innerHTML = rows
+    .map(
+      ([label, value]) =>
+        `<div class="stat-row"><span class="stat-label">${label}</span><span class="stat-value">${value}</span></div>`,
+    )
+    .join('');
+}
+
+function renderMissions(): void {
+  const el = document.getElementById('mission-list');
+  if (!el) return;
+  el.innerHTML = MISSIONS.map(
+    (m) => `
+      <div class="mission-card btn" data-fn="menu-act" data-act="play" data-value="${m.level}">
+        <div class="mission-name">${m.name}</div>
+        <div class="mission-desc">${m.desc}</div>
+      </div>`,
+  ).join('');
+}
+
+// --- Keybindings UI --------------------------------------------------------
+
+let listeningAction: string | null = null;
+
+function renderKeybindings(): void {
+  const el = document.getElementById('keybindings-list');
+  if (!el) return;
+  const groups: string[] = [];
+  for (const action of KEY_ACTIONS) {
+    if (!groups.includes(action.group)) groups.push(action.group);
+  }
+  el.innerHTML = groups
+    .map((group) => {
+      const rows = KEY_ACTIONS.filter((a) => a.group === group)
+        .map((a) => {
+          const listening = listeningAction === a.id;
+          const label = listening ? 'Press a key…' : keyLabel(codeFor(a.id));
+          return `
+            <div class="keybind-row">
+              <span class="keybind-label">${a.label}</span>
+              <div class="btn btn-key ${listening ? 'listening' : ''}"
+                   data-fn="menu-act" data-act="rebind" data-value="${a.id}">${label}</div>
+            </div>`;
+        })
+        .join('');
+      return `<div class="keybind-group"><h3>${group}</h3>${rows}</div>`;
+    })
+    .join('');
+}
+
+function stopListening(): void {
+  if (listeningAction !== null) {
+    window.removeEventListener('keydown', onRebindKey, true);
+    listeningAction = null;
+  }
+}
+
+function onRebindKey(e: KeyboardEvent): void {
+  // Capture the key before any game/menu handler sees it.
+  e.preventDefault();
+  e.stopPropagation();
+  const action = listeningAction;
+  stopListening();
+  if (!action) return;
+  const code = e.keyCode || e.which;
+  // Esc cancels the rebind rather than binding to Esc (Esc is reserved in-game).
+  if (code !== 27) {
+    const swapped = setBinding(action, code);
+    if (swapped) {
+      const swappedLabel = KEY_ACTIONS.find((a) => a.id === swapped)?.label ?? swapped;
+      showToast(`"${keyLabel(code)}" was already used — "${swappedLabel}" moved to a free key.`);
+    }
+  }
+  renderKeybindings();
+}
+
+function beginRebind(actionId: string): void {
+  if (listeningAction === actionId) {
+    // Clicking the listening button again cancels.
+    stopListening();
+    renderKeybindings();
+    return;
+  }
+  stopListening();
+  listeningAction = actionId;
+  renderKeybindings();
+  window.addEventListener('keydown', onRebindKey, true);
+}
+
+// --- Small transient toast -------------------------------------------------
+
+let toastTimer: ReturnType<typeof setTimeout> | undefined;
+function showToast(message: string): void {
+  let el = document.getElementById('menu-toast');
+  if (!el) {
+    el = document.createElement('div');
+    el.id = 'menu-toast';
+    document.body.appendChild(el);
+  }
+  el.textContent = message;
+  el.classList.add('show');
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => el && el.classList.remove('show'), 3200);
+}
+
+// --- Actions ---------------------------------------------------------------
+
+function launchMission(level: string): void {
+  const volume = currentOptions?.volume ?? 1;
+  window.location.href = `game.html?volume=${volume}&level=${encodeURIComponent(level)}`;
+}
+
+function handleAction(act: string | null, value: string | null): void {
+  switch (act) {
+    case 'settings-category':
+      if (value) selectSettingsCategory(value);
+      break;
+    case 'play':
+      if (value) launchMission(value);
+      break;
+    case 'rebind':
+      if (value) beginRebind(value);
+      break;
+    case 'reset-keybinds':
+      stopListening();
+      resetBindings();
+      renderKeybindings();
+      showToast('Controls reset to defaults.');
+      break;
+    case 'reset-all-settings':
+      stopListening();
+      remove(STORAGE_OPTIONS);
+      resetBindings();
+      currentOptions = getSavedData();
+      applyVolumeToSlider();
+      renderKeybindings();
+      showToast('All settings reset to defaults.');
+      break;
+    default:
+      // Unknown / navigation-only elements are handled elsewhere.
+      break;
+  }
+}
+
+// --- Volume slider ---------------------------------------------------------
+
+function applyVolumeToSlider(): void {
+  const slider = document.getElementById('volume-total') as HTMLInputElement | null;
+  if (slider) slider.value = String(Math.round((currentOptions?.volume ?? 1) * 100));
+}
+
+function wireVolumeSlider(): void {
+  const slider = document.getElementById('volume-total') as HTMLInputElement | null;
+  if (!slider) return;
+  slider.addEventListener('input', () => {
+    const volume = Math.max(0, Math.min(100, Number(slider.value))) / 100;
+    currentOptions = assign(STORAGE_OPTIONS, { volume });
+  });
+}
+
+// --- Bootstrap -------------------------------------------------------------
+
+let started = false;
+export function initMenu(): void {
+  if (started) return;
+  started = true;
+
+  currentOptions = getSavedData();
+
+  document.body.addEventListener('click', (e) => {
+    const target = e.target as HTMLElement;
+
+    // Navigation via data-view.
+    const viewEl = target.closest('[data-view]') as HTMLElement | null;
+    if (viewEl) {
+      const view = viewEl.dataset.view;
+      if (view) {
+        // Leaving a screen mid-rebind should not keep listening for keys.
+        stopListening();
+        setMenuView(view);
+        if (view === 'settings') {
+          runBindings(currentOptions as unknown as object);
+          selectSettingsCategory(currentSettingsCategory);
+          renderKeybindings();
+        } else if (view === 'achievements') {
+          renderStats();
+        }
+      }
+      return;
+    }
+
+    // Actions via data-fn="menu-act".
+    const fnEl = target.closest('[data-fn]') as HTMLElement | null;
+    if (fnEl && fnEl.dataset.fn === 'menu-act') {
+      handleAction(fnEl.dataset.act ?? null, fnEl.dataset.value ?? null);
+    }
+  });
+
+  wireVolumeSlider();
+  applyVolumeToSlider();
+  renderMissions();
+  renderKeybindings();
+  renderStats();
+  selectSettingsCategory(currentSettingsCategory);
+}

--- a/src/menu/storage.ts
+++ b/src/menu/storage.ts
@@ -1,0 +1,108 @@
+/**
+ * Settings persistence for the menu.
+ *
+ * Ported from Some of You May Die's `src/storage.ts` and trimmed to what a static,
+ * browser-only build needs (no Electron/Steam disk mirror, no localization coupling).
+ * The contract is the same as the game it came from:
+ *
+ *   - Most settings live together in one JSON blob under the `OPTIONS` key.
+ *   - `assign(OPTIONS, { foo: bar })` merges a change in, re-reads, and re-applies.
+ *   - `runBindings(options)` lights up the `.btn[data-bind]` that matches each option's
+ *     stored value, so a toggle button shows the persisted choice with no per-button code.
+ *   - `getSavedData()` on load parses the blob over the defaults, publishes it to
+ *     `globalThis.options`, applies it, and runs the bindings.
+ *
+ * Rebindable keyboard controls persist separately through `src/systems/keybindings.ts`
+ * (their own `stealthControls` key), exactly as SoYMD keeps controls out of the OPTIONS
+ * blob under its own `controls` key.
+ */
+
+export const STORAGE_OPTIONS = 'OPTIONS';
+
+export interface MenuOptions {
+  /** Master volume 0..1, threaded into the game launch URL as `?volume=`. */
+  volume: number;
+}
+
+const defaultOptions: MenuOptions = {
+  volume: 1,
+};
+
+export function get(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch (e) {
+    // localStorage access itself can throw under restrictive browser privacy settings.
+    console.warn('storage: unable to read from localStorage', key, e);
+    return null;
+  }
+}
+
+export function set(key: string, value: unknown): void {
+  try {
+    localStorage.setItem(key, String(value));
+  } catch (e) {
+    // Persistence is a nice-to-have — never let a storage failure break the menu.
+    console.warn('storage: unable to write to localStorage', key, e);
+  }
+}
+
+export function remove(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch (e) {
+    console.warn('storage: unable to remove from localStorage', key, e);
+  }
+}
+
+/** Merge `value` into the JSON object stored at `key`, then re-apply all saved data. */
+export function assign(key: string, value: object): MenuOptions {
+  const existing = get(key);
+  let json: Record<string, unknown> = {};
+  if (existing) {
+    try {
+      json = JSON.parse(existing);
+    } catch (e) {
+      console.warn('storage: stored value was not valid JSON, overwriting', key, e);
+    }
+  }
+  set(key, JSON.stringify(Object.assign(json, value)));
+  return getSavedData();
+}
+
+/**
+ * For each `[key, value]`, toggle `.active` on every `.btn[data-bind="key"]` whose
+ * `data-value` equals the stored value. This is the read-to-DOM mechanism that keeps
+ * option buttons showing the persisted choice.
+ */
+export function runBindings(value: object): void {
+  for (const [k, v] of Object.entries(value)) {
+    const matchingEls = document.querySelectorAll(`[data-bind="${k}"]`);
+    for (const el of Array.from(matchingEls)) {
+      if (el.classList.contains('btn')) {
+        el.classList.toggle('active', (el as HTMLElement).dataset.value === String(v));
+      }
+    }
+  }
+}
+
+/**
+ * Parse the OPTIONS blob over the defaults, publish it to `globalThis.options`, apply the
+ * settings that have a runtime effect, and light up the matching option buttons. Returns
+ * the resolved options so callers (e.g. the Play button) can read them synchronously.
+ */
+export function getSavedData(): MenuOptions {
+  const stored = get(STORAGE_OPTIONS);
+  let parsed: Partial<MenuOptions> = {};
+  if (stored) {
+    try {
+      parsed = JSON.parse(stored);
+    } catch (e) {
+      console.warn('storage: unable to parse OPTIONS, using defaults', e);
+    }
+  }
+  const options: MenuOptions = { ...defaultOptions, ...parsed };
+  (globalThis as any).options = options;
+  runBindings(options as unknown as object);
+  return options;
+}

--- a/src/systems/input.ts
+++ b/src/systems/input.ts
@@ -17,6 +17,7 @@ import { cyclePhysicsDebug } from './physics_debug';
 import { cycleBreachDebug } from './breach_debug';
 import { physics } from '../physics';
 import { isInCar, toggleCar } from './car';
+import { getBindings } from './keybindings';
 
 export function mouseMove(e){
     //Viewport coords, not document coords: camera.getMouse wants the position within the
@@ -41,16 +42,20 @@ export function addKeyHandlers(){
     window.onkeydown = function(e){
         //this function is called every frame that said key is down
         var code = e.keyCode ? e.keyCode : e.which;
+        //Resolve the physical key against the (possibly rebound) control map. Every numeric
+        //keyCode below used to be a hard-coded literal; they now come from keybindings.ts so
+        //the menu's Controls settings can remap them. See src/systems/keybindings.ts.
+        var kb = getBindings();
         //keyinfo[code] = String.fromCharCode(code);
         if(hero.alive && isInCar()){
             //Driving the van: only the car controls respond. Weapons, the bomb, the mask,
             //lockpicking and body-dragging are all unavailable until you get out (E).
-            if(code == 87){keys['w'] = true;}
-            if(code == 65){keys['a'] = true;}
-            if(code == 83){keys['s'] = true;}
-            if(code == 68){keys['d'] = true;}
-            if(code == 32){keys['space'] = true;}//handbrake
-            if(code == 69){if(!keys['e'])toggleCar();keys['e'] = true;}//E: get out
+            if(code == kb.move_up){keys['w'] = true;}
+            if(code == kb.move_left){keys['a'] = true;}
+            if(code == kb.move_down){keys['s'] = true;}
+            if(code == kb.move_right){keys['d'] = true;}
+            if(code == kb.interact){keys['space'] = true;}//handbrake
+            if(code == kb.vehicle){if(!keys['e'])toggleCar();keys['e'] = true;}//get out
         }else if(hero.alive){
             /*
             if(code == 49){hero.changeGun(0);}//key 1
@@ -60,12 +65,12 @@ export function addKeyHandlers(){
             if(code == 53){hero.changeGun(4);}//key 5
             if(code == 54){hero.changeGun(5);}//key 6
             */
-            if(code == 87){keys['w'] = true;}
-            if(code == 65){keys['a'] = true;}
-            if(code == 83){keys['s'] = true;}
-            if(code == 68){keys['d'] = true;}
-            if(code == 80){
-                //key p
+            if(code == kb.move_up){keys['w'] = true;}
+            if(code == kb.move_left){keys['a'] = true;}
+            if(code == kb.move_down){keys['s'] = true;}
+            if(code == kb.move_right){keys['d'] = true;}
+            if(code == kb.spyglass){
+                //spyglass / binoculars
                 hero.spyglass_equipped = !hero.spyglass_equipped;
 
                 if(hero.spyglass_equipped){
@@ -75,7 +80,7 @@ export function addKeyHandlers(){
                 }
 
             }
-            if(code == 71){
+            if(code == kb.draw_weapon){
                 // !keys['g'] makes it so that it will only be called once for a single press of the letter
                 if(!keys['g']){
                     hero.gunOut = !hero.gunOut;
@@ -92,32 +97,32 @@ export function addKeyHandlers(){
                 //'p'
                 pause = !pause;
             }*/
-            if(code == 82){
+            if(code == kb.reload){
                 keys['r'] = true;
                 hero.reload();
             }
-            if(code == 78){
-                //key n: cycle the nav debug overlay (off / paths / regions / danger / flow)
+            if(code == kb.nav_debug){
+                //cycle the nav debug overlay (off / paths / regions / danger / flow)
                 if(!keys['n']){
                     newMessage('Nav overlay: ' + cycleNavDebug());
                 }
                 keys['n'] = true;
             }
-            if(code == 66){
-                //key b: cycle the physics/fog overlay (off / fixtures / occluders / polygon)
+            if(code == kb.physics_debug){
+                //cycle the physics/fog overlay (off / fixtures / occluders / polygon)
                 if(!keys['b']){
                     newMessage('Physics overlay: ' + cyclePhysicsDebug());
                 }
                 keys['b'] = true;
             }
-            if(code == 72){
-                //key h: cycle the wall-destruction overlay (off / materials / hp)
+            if(code == kb.wall_debug){
+                //cycle the wall-destruction overlay (off / materials / hp)
                 if(!keys['h']){
                     newMessage('Wall overlay: ' + cycleBreachDebug());
                 }
                 keys['h'] = true;
             }
-            if(code == 70){
+            if(code == kb.bomb){
                 //plant bomb
                 if(!keys['f'] && !bomb.sprite.visible){
 
@@ -156,7 +161,7 @@ export function addKeyHandlers(){
                 keys['f'] = true;
 
             }
-            if(code == 86){
+            if(code == kb.mask){
                 // !keys['v'] makes it so that it will only be called once for a single press of the letter
                 if(!keys['v']){
                     circProgBar.heroMaskProg(hero.ability_toggle_mask_speed,useMask,!hero.masked);
@@ -165,7 +170,7 @@ export function addKeyHandlers(){
                 }
                 keys['v'] = true;
             }
-            if(code == 16){
+            if(code == kb.sprint){
                 keys['shift'] = true;
                 //cannot sprint while dragging something
                 if(!hero_drag_target){
@@ -173,7 +178,7 @@ export function addKeyHandlers(){
                 }
 
             }
-            if(code == 32){
+            if(code == kb.interact){
                 keys['space'] = true;
                 if(!hero_drag_target){
                     if(!grid.a_door_is_being_unlocked){
@@ -282,11 +287,11 @@ export function addKeyHandlers(){
                 }
 
             }
-            if(code == 69){if(!keys['e'])toggleCar();keys['e'] = true;}//E: get into the van
+            if(code == kb.vehicle){if(!keys['e'])toggleCar();keys['e'] = true;}//get into the van
         }
 
         if(code == 27){
-            //esc
+            //esc — always available, not rebindable
             startMenu();
         }
 
@@ -294,29 +299,32 @@ export function addKeyHandlers(){
     };
     window.onkeyup = function(e){
         var code = e.keyCode ? e.keyCode : e.which;
-        if(code == 87){keys['w'] = false;}
-        if(code == 65){keys['a'] = false;}
-        if(code == 83){keys['s'] = false;}
-        if(code == 68){keys['d'] = false;}
-        if(code == 70){keys['f'] = false;}
-        if(code == 71){keys['g'] = false;}
-        if(code == 69){keys['e'] = false;}
-        if(code == 82){keys['r'] = false;}
-        if(code == 78){keys['n'] = false;}
-        if(code == 66){keys['b'] = false;}
-        if(code == 72){keys['h'] = false;}
-        if(code == 86){
+        //Same (possibly rebound) control map as keydown, so a released key clears the flag
+        //its bound action set. See src/systems/keybindings.ts.
+        var kb = getBindings();
+        if(code == kb.move_up){keys['w'] = false;}
+        if(code == kb.move_left){keys['a'] = false;}
+        if(code == kb.move_down){keys['s'] = false;}
+        if(code == kb.move_right){keys['d'] = false;}
+        if(code == kb.bomb){keys['f'] = false;}
+        if(code == kb.draw_weapon){keys['g'] = false;}
+        if(code == kb.vehicle){keys['e'] = false;}
+        if(code == kb.reload){keys['r'] = false;}
+        if(code == kb.nav_debug){keys['n'] = false;}
+        if(code == kb.physics_debug){keys['b'] = false;}
+        if(code == kb.wall_debug){keys['h'] = false;}
+        if(code == kb.mask){
             //on release of key only
             //if(keys['v'])circProgBar.stop();//stop putting on mask
             keys['v'] = false;
         }
-        if(code == 16){
+        if(code == kb.sprint){
             keys['shift'] = false;
             if(hero_drag_target==null){
                 hero.speed = hero.speed_walk;
             }
         }
-        if(code == 32){
+        if(code == kb.interact){
             keys['space'] = false;
             //if hero was dragging something, drop it. (Don't drop a guard while he's being choked
             if(hero_drag_target && !hero_drag_target.alive){

--- a/src/systems/keybindings.ts
+++ b/src/systems/keybindings.ts
@@ -1,0 +1,191 @@
+/**
+ * Rebindable keyboard controls.
+ *
+ * The game used to hard-code every `keyCode` inline in `input.ts` (e.g. `code == 87`
+ * for W). This module is the single indirection layer between a physical key and the
+ * gameplay action it triggers, so the player can rebind keys from the menu's Settings
+ * screen and have the game honour it.
+ *
+ * Persistence deliberately mirrors how the ported Some of You May Die menu stores its
+ * settings: a JSON blob in `localStorage` under a stable key, read once at load and
+ * re-applied on demand. Both pages read the same key, so a binding chosen on `menu.html`
+ * is in effect the next time `game.html` boots.
+ *
+ * It is imported by BOTH the game (`input.ts`, which resolves each pressed key through
+ * `codeFor` / `actionForCode`) and the menu (which renders the rebinding widget). It has
+ * no dependency on either side's globals so it can live in both bundles unchanged.
+ */
+
+export type KeyGroup = 'Movement' | 'Actions' | 'Debug';
+
+export interface KeyAction {
+  /** Stable id used as the persistence key and the `input.ts` lookup. */
+  id: string;
+  /** Human-facing label shown in the controls list. */
+  label: string;
+  /** The `keyCode` this action defaults to. */
+  defaultCode: number;
+  /** Grouping for the settings UI. */
+  group: KeyGroup;
+}
+
+/**
+ * The rebindable keyboard actions, in the order they should appear in the UI.
+ *
+ * Every entry here corresponds to a `keyCode` comparison in `src/systems/input.ts`; when
+ * a binding here changes, that handler picks it up through `codeFor()`. Mouse buttons
+ * (shoot / pick-up-gun), the wheel zoom and Esc are intentionally NOT rebindable — they
+ * are not keyboard keys — and the weapon-switch number keys are omitted because they are
+ * currently disabled in `input.ts`.
+ *
+ * Keep this list and the handlers in `input.ts` in lock-step (see CLAUDE.md, "Controls").
+ */
+export const KEY_ACTIONS: KeyAction[] = [
+  { id: 'move_up', label: 'Move Up', defaultCode: 87, group: 'Movement' }, // W
+  { id: 'move_down', label: 'Move Down', defaultCode: 83, group: 'Movement' }, // S
+  { id: 'move_left', label: 'Move Left', defaultCode: 65, group: 'Movement' }, // A
+  { id: 'move_right', label: 'Move Right', defaultCode: 68, group: 'Movement' }, // D
+  { id: 'sprint', label: 'Sprint (hold)', defaultCode: 16, group: 'Movement' }, // Shift
+  { id: 'interact', label: 'Interact / Lockpick / Drag / Choke', defaultCode: 32, group: 'Actions' }, // Space
+  { id: 'draw_weapon', label: 'Draw / Holster Weapon', defaultCode: 71, group: 'Actions' }, // G
+  { id: 'reload', label: 'Reload', defaultCode: 82, group: 'Actions' }, // R
+  { id: 'mask', label: 'Put On / Take Off Mask', defaultCode: 86, group: 'Actions' }, // V
+  { id: 'bomb', label: 'Place / Detonate Explosive', defaultCode: 70, group: 'Actions' }, // F
+  { id: 'spyglass', label: 'Spyglass / Binoculars', defaultCode: 80, group: 'Actions' }, // P
+  { id: 'vehicle', label: 'Enter / Exit Van', defaultCode: 69, group: 'Actions' }, // E
+  { id: 'nav_debug', label: 'Nav Overlay', defaultCode: 78, group: 'Debug' }, // N
+  { id: 'physics_debug', label: 'Physics / Fog Overlay', defaultCode: 66, group: 'Debug' }, // B
+  { id: 'wall_debug', label: 'Wall Destruction Overlay', defaultCode: 72, group: 'Debug' }, // H
+];
+
+/**
+ * localStorage key. Named to sit alongside the other ported menu settings; the value is a
+ * JSON object mapping action id -> keyCode.
+ */
+const STORAGE_KEY = 'stealthControls';
+
+/** keyCode -> short display label, for the controls list and the rebind buttons. */
+const KEY_LABELS: Record<number, string> = {
+  8: 'Backspace', 9: 'Tab', 13: 'Enter', 16: 'Shift', 17: 'Ctrl', 18: 'Alt',
+  19: 'Pause', 20: 'Caps', 27: 'Esc', 32: 'Space',
+  33: 'Page Up', 34: 'Page Down', 35: 'End', 36: 'Home',
+  37: '←', 38: '↑', 39: '→', 40: '↓',
+  45: 'Insert', 46: 'Delete',
+  48: '0', 49: '1', 50: '2', 51: '3', 52: '4', 53: '5', 54: '6', 55: '7', 56: '8', 57: '9',
+  65: 'A', 66: 'B', 67: 'C', 68: 'D', 69: 'E', 70: 'F', 71: 'G', 72: 'H', 73: 'I',
+  74: 'J', 75: 'K', 76: 'L', 77: 'M', 78: 'N', 79: 'O', 80: 'P', 81: 'Q', 82: 'R',
+  83: 'S', 84: 'T', 85: 'U', 86: 'V', 87: 'W', 88: 'X', 89: 'Y', 90: 'Z',
+  96: 'Num 0', 97: 'Num 1', 98: 'Num 2', 99: 'Num 3', 100: 'Num 4', 101: 'Num 5',
+  102: 'Num 6', 103: 'Num 7', 104: 'Num 8', 105: 'Num 9',
+  106: 'Num *', 107: 'Num +', 109: 'Num -', 110: 'Num .', 111: 'Num /',
+  112: 'F1', 113: 'F2', 114: 'F3', 115: 'F4', 116: 'F5', 117: 'F6', 118: 'F7', 119: 'F8',
+  120: 'F9', 121: 'F10', 122: 'F11', 123: 'F12',
+  186: ';', 187: '=', 188: ',', 189: '-', 190: '.', 191: '/', 192: '`',
+  219: '[', 220: '\\', 221: ']', 222: "'",
+};
+
+/** Human-readable label for a keyCode, e.g. `87` -> `"W"`. */
+export function keyLabel(code: number): string {
+  return KEY_LABELS[code] || `Key ${code}`;
+}
+
+/**
+ * Cached resolved map (action id -> keyCode). Built lazily from storage merged over the
+ * defaults so a stored file that predates a new action still resolves that action to its
+ * default. Cleared by `setBinding` / `resetBindings` so it always reflects the latest.
+ */
+let cache: Record<string, number> | null = null;
+
+function readStored(): Record<string, number> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, number>) : {};
+  } catch (e) {
+    // localStorage access itself can throw under restrictive browser privacy settings;
+    // bindings are a nice-to-have, so fall back to defaults rather than break input.
+    console.warn('keybindings: unable to read stored controls', e);
+    return {};
+  }
+}
+
+/** The current action-id -> keyCode map, defaults filled in for anything unstored. */
+export function getBindings(): Record<string, number> {
+  if (cache) return cache;
+  const stored = readStored();
+  const map: Record<string, number> = {};
+  for (const action of KEY_ACTIONS) {
+    const stored_code = stored[action.id];
+    map[action.id] = typeof stored_code === 'number' && Number.isFinite(stored_code)
+      ? stored_code
+      : action.defaultCode;
+  }
+  cache = map;
+  return map;
+}
+
+/** The keyCode currently bound to `actionId` (its default if unbound/unknown). */
+export function codeFor(actionId: string): number {
+  return getBindings()[actionId];
+}
+
+/** The action id currently bound to `code`, or undefined if no action uses that key. */
+export function actionForCode(code: number): string | undefined {
+  const map = getBindings();
+  for (const id in map) {
+    if (map[id] === code) return id;
+  }
+  return undefined;
+}
+
+function persist(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(getBindings()));
+  } catch (e) {
+    console.warn('keybindings: unable to persist controls', e);
+  }
+}
+
+/**
+ * Bind `actionId` to `code`. If another action already uses that key it is swapped onto
+ * the key `actionId` used to hold, so there is never a duplicate binding (two actions on
+ * one key would both fire). Returns the id of the action that got swapped, if any.
+ */
+export function setBinding(actionId: string, code: number): string | undefined {
+  const map = getBindings();
+  if (!(actionId in map)) return undefined;
+  const previousCode = map[actionId];
+  let swapped: string | undefined;
+  for (const id in map) {
+    if (id !== actionId && map[id] === code) {
+      map[id] = previousCode;
+      swapped = id;
+      break;
+    }
+  }
+  map[actionId] = code;
+  cache = map;
+  persist();
+  return swapped;
+}
+
+/** Restore every action to its default key. */
+export function resetBindings(): void {
+  cache = null;
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.warn('keybindings: unable to clear stored controls', e);
+  }
+  getBindings();
+}
+
+/**
+ * Force a re-read from storage on the next lookup. `input.ts` reads bindings once when its
+ * handlers are installed at game start; this lets a caller invalidate the cache if the
+ * stored value changed underneath it.
+ */
+export function reloadBindings(): void {
+  cache = null;
+}

--- a/test/systems/keybindings.test.ts
+++ b/test/systems/keybindings.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  KEY_ACTIONS,
+  keyLabel,
+  getBindings,
+  codeFor,
+  actionForCode,
+  setBinding,
+  resetBindings,
+  reloadBindings,
+} from '../../src/systems/keybindings';
+
+// Minimal in-memory localStorage so the module's persistence path is exercised under the
+// node test environment (which has no real localStorage).
+class MemoryStorage {
+  private store: Record<string, string> = {};
+  getItem(k: string): string | null {
+    return k in this.store ? this.store[k] : null;
+  }
+  setItem(k: string, v: string): void {
+    this.store[k] = String(v);
+  }
+  removeItem(k: string): void {
+    delete this.store[k];
+  }
+}
+
+beforeEach(() => {
+  (globalThis as any).localStorage = new MemoryStorage();
+  resetBindings();
+});
+
+describe('keybindings', () => {
+  it('resolves every action to its default when nothing is stored', () => {
+    const bindings = getBindings();
+    for (const action of KEY_ACTIONS) {
+      expect(bindings[action.id]).toBe(action.defaultCode);
+      expect(codeFor(action.id)).toBe(action.defaultCode);
+    }
+  });
+
+  it('maps a keyCode back to the action that owns it', () => {
+    // Defaults: 87 = W = move_up, 32 = Space = interact
+    expect(actionForCode(87)).toBe('move_up');
+    expect(actionForCode(32)).toBe('interact');
+    expect(actionForCode(999)).toBeUndefined();
+  });
+
+  it('rebinds an action and persists it across a cache reload', () => {
+    // Rebind reload (R/82) to K (75), which no other action uses.
+    const swapped = setBinding('reload', 75);
+    expect(swapped).toBeUndefined();
+    expect(codeFor('reload')).toBe(75);
+
+    // Drop the in-memory cache; the value must survive via localStorage.
+    reloadBindings();
+    expect(codeFor('reload')).toBe(75);
+    expect(actionForCode(75)).toBe('reload');
+  });
+
+  it('swaps keys when a rebind collides with another action to avoid duplicates', () => {
+    // move_up = W(87), move_down = S(83). Bind move_up to S: move_down should inherit W.
+    const swapped = setBinding('move_up', 83);
+    expect(swapped).toBe('move_down');
+    expect(codeFor('move_up')).toBe(83);
+    expect(codeFor('move_down')).toBe(87);
+    // No key is bound to two actions.
+    const seen = new Set<number>();
+    for (const action of KEY_ACTIONS) {
+      const code = codeFor(action.id);
+      expect(seen.has(code)).toBe(false);
+      seen.add(code);
+    }
+  });
+
+  it('resetBindings restores defaults', () => {
+    setBinding('reload', 75);
+    expect(codeFor('reload')).toBe(75);
+    resetBindings();
+    expect(codeFor('reload')).toBe(82);
+  });
+
+  it('keyLabel gives readable names with a fallback', () => {
+    expect(keyLabel(87)).toBe('W');
+    expect(keyLabel(32)).toBe('Space');
+    expect(keyLabel(16)).toBe('Shift');
+    expect(keyLabel(4242)).toBe('Key 4242');
+  });
+});


### PR DESCRIPTION
## Summary

Completely redesigns the menu interface with a modern dark/gold theme and adds a full rebindable keyboard controls system. The menu now features a structured view-switching architecture (Main, Play, Settings, Stats, Credits) with persistent settings storage, while the game's input handler is refactored to respect player-configured key bindings instead of hard-coded key codes.

## Key Changes

**Menu UI Redesign (`menu.html`)**
- Replaced legacy table-based layout with a modern flexbox-based design
- Introduced a dark theme with gold accents (`--bg`, `--panel`, `--gold` CSS variables)
- Implemented view-switching system: single `#main-menu` container with `.view` siblings, toggled via `menu-{name}` body class
- Added responsive design with `clamp()` sizing and mobile viewport meta tag
- Created reusable button component with hover/active states and blue variant for primary actions
- Structured Settings panel with sidebar navigation and scrollable content areas
- Added Mission Select with card-based layout showing mission name and description
- Implemented Stats/Achievements view with stat rows and achievement grid
- Added Credits view with scrollable content
- Included transient toast notifications for user feedback

**Keyboard Controls System (`src/systems/keybindings.ts`)**
- New module defining `KEY_ACTIONS` array: 15 rebindable actions (movement, interact, draw weapon, reload, mask, bomb, spyglass, vehicle, debug overlays)
- Each action has stable id, human label, default keyCode, and group (Movement/Actions/Debug)
- `codeFor(actionId)` and `actionForCode(keyCode)` provide bidirectional lookup
- `setBinding(actionId, keyCode)` handles rebinding with collision detection—if a key is already bound, swaps the conflicting action to a free key
- `resetBindings()` and `reloadBindings()` manage cache and persistence
- Persistence via `localStorage` under `stealthControls` key (JSON object mapping action id → keyCode)
- Comprehensive test suite (`test/systems/keybindings.test.ts`) covering defaults, lookup, rebinding, collision handling, and persistence

**Menu Behavior (`src/menu/menu.ts`)**
- New module implementing delegated click handler on `document.body` driving all menu actions via data attributes
- `setMenuView(name)` toggles between views by swapping `menu-*` body class
- Mission Select renders playable missions and launches game with persisted volume
- Settings panel with three categories: Controls (keybinding UI), Audio (volume slider), Other (reset options)
- Keybinding UI with visual feedback: shows current binding, "Press a key…" prompt while listening, pulsing animation during rebind, Esc to cancel
- `beginRebind()` / `stopListening()` manage the rebind flow with global keydown listener
- Stats rendering reads legacy `jo_store_*` counters (wins, loses, guardsShot, guardsChoked)
- Toast notifications for rebind collisions and user actions

**Settings Storage (`src/menu/storage.ts`)**
- Ported from Some of You May Die's storage pattern
- `MenuOptions` interface with `volume` field (0..1, threaded into game launch URL)
- `assign(key, value)` merges changes into JSON blob and re-applies
- `runBindings(options)` lights up `.btn[data-bind]` matching persisted values (no per-button code needed)
- `getSavedData()` on load parses blob over defaults, publishes to `globalThis.options`, applies, runs bindings
- Graceful error handling for localStorage access failures

**Game Input Integration (`src/systems/input.ts`)**
- Refactored `addKeyHandlers()` to call `getBindings()` once per frame
- Replaced all hard-coded keyCode literals (87 for W, 65 for A, etc.) with lookups from the bindings map
- Updated both normal gameplay and vehicle (van) control paths
- Comments added explaining the indirection layer for future maintainers

**Documentation (`CLAUDE.md`)**
- Updated Controls section with guidance: when adding/removing/reb

https://claude.ai/code/session_01UoteCbRF8L7no6ex1ackyW